### PR TITLE
Log misconfigured .unused.yml configuration to stderr

### DIFF
--- a/crates/cli/src/cli_configuration.rs
+++ b/crates/cli/src/cli_configuration.rs
@@ -10,7 +10,7 @@ use token_search::{TokenSearchConfig, TokenSearchResults};
 pub struct CliConfiguration {
     token_search_config: TokenSearchConfig,
     analysis_filter: AnalysisFilter,
-    project_configuration: ProjectConfiguration,
+    pub project_configuration: ProjectConfiguration,
     outcome: TokenUsageResults,
 }
 

--- a/crates/cli/src/formatters/compact.rs
+++ b/crates/cli/src/formatters/compact.rs
@@ -1,5 +1,4 @@
-use super::super::cli_configuration::CliConfiguration;
-use colored::*;
+use super::internal::{colored::*, configuration_warnings, CliConfiguration};
 use token_analysis::UsageLikelihoodStatus;
 
 pub fn format(cli_config: CliConfiguration) {
@@ -20,4 +19,6 @@ pub fn format(cli_config: CliConfiguration) {
             file_width = file_width
         );
     }
+
+    configuration_warnings(&cli_config.project_configuration);
 }

--- a/crates/cli/src/formatters/internal.rs
+++ b/crates/cli/src/formatters/internal.rs
@@ -1,0 +1,33 @@
+pub use super::super::{cli_configuration::CliConfiguration, flags::Flags};
+pub use colored;
+use colored::*;
+use project_configuration::{ProjectConfiguration, ProjectConfigurations};
+
+pub fn configuration_warnings(config: &ProjectConfiguration) {
+    for low_likelihood in config.low_likelihood.iter() {
+        let conflicts = low_likelihood.conflicts();
+        if conflicts.len() > 0 {
+            eprintln!(
+                "Issues detected in YAML low-likelihood configuration: {}",
+                low_likelihood.name.cyan()
+            );
+        }
+
+        for conflict in conflicts {
+            let keys: Vec<_> = conflict
+                .assertions()
+                .into_iter()
+                .filter_map(ProjectConfigurations::assertion_to_key)
+                .collect();
+
+            eprintln!(
+                "   Conflicting keys: ({})",
+                format!("{}", keys.len()).yellow()
+            );
+
+            for key in keys {
+                eprintln!("   * {}", key.yellow());
+            }
+        }
+    }
+}

--- a/crates/cli/src/formatters/json.rs
+++ b/crates/cli/src/formatters/json.rs
@@ -1,6 +1,7 @@
-use super::super::cli_configuration::CliConfiguration;
+use super::internal::{configuration_warnings, CliConfiguration};
 use serde_json;
 
 pub fn format(cli_config: CliConfiguration) {
-    println!("{}", serde_json::to_string(&cli_config.for_json()).unwrap())
+    println!("{}", serde_json::to_string(&cli_config.for_json()).unwrap());
+    configuration_warnings(&cli_config.project_configuration);
 }

--- a/crates/cli/src/formatters/mod.rs
+++ b/crates/cli/src/formatters/mod.rs
@@ -1,3 +1,4 @@
 pub mod compact;
+pub mod internal;
 pub mod json;
 pub mod standard;

--- a/crates/cli/src/formatters/standard.rs
+++ b/crates/cli/src/formatters/standard.rs
@@ -1,6 +1,4 @@
-use super::super::cli_configuration::CliConfiguration;
-use super::super::flags::Flags;
-use colored::*;
+use super::internal::{colored::*, configuration_warnings, CliConfiguration, Flags};
 use std::collections::HashSet;
 use token_analysis::UsageLikelihoodStatus;
 
@@ -43,11 +41,13 @@ pub fn format(cmd: Flags, cli_config: CliConfiguration) {
     }
 
     if !cmd.no_summary {
-        usage_summary(tokens_list.len(), files_list.len(), cli_config);
+        usage_summary(tokens_list.len(), files_list.len(), &cli_config);
     }
+
+    configuration_warnings(&cli_config.project_configuration);
 }
 
-fn usage_summary(tokens_count: usize, files_count: usize, cli_config: CliConfiguration) {
+fn usage_summary(tokens_count: usize, files_count: usize, cli_config: &CliConfiguration) {
     println!("");
     println!("{}", "== UNUSED SUMMARY ==".white());
     println!("   Tokens found: {}", colorize_total(tokens_count));

--- a/crates/project_configuration/src/config.rs
+++ b/crates/project_configuration/src/config.rs
@@ -1,4 +1,4 @@
-use super::value_assertion::Assertion;
+use super::value_assertion::{Assertion, AssertionConflict};
 use std::path::Path;
 use token_search::{TokenSearchResult, TokenSearchResults};
 
@@ -35,6 +35,56 @@ impl LowLikelihoodConfig {
     pub fn matches(&self, token_search_result: &TokenSearchResult) -> bool {
         self.matchers.iter().all(|a| a.matches(token_search_result))
     }
+
+    pub fn conflicts(&self) -> Vec<AssertionConflict> {
+        vec![
+            Self::build_conflicts(self.path_assertions()).map(AssertionConflict::PathConflict),
+            Self::build_conflicts(self.token_assertions()).map(AssertionConflict::TokenConflict),
+        ]
+        .into_iter()
+        .filter_map(|v| v)
+        .collect()
+    }
+
+    fn build_conflicts(assertions: Vec<&Assertion>) -> Option<Vec<Assertion>> {
+        let equals_assertions: Vec<&Assertion> = assertions
+            .clone()
+            .into_iter()
+            .filter(|m| m.matcher().full_equals())
+            .collect();
+        let partial_equals_assertions: Vec<&Assertion> = assertions
+            .into_iter()
+            .filter(|m| !m.matcher().full_equals())
+            .collect();
+
+        if equals_assertions.len() > 0 && partial_equals_assertions.len() > 0 {
+            let mut results = equals_assertions.clone();
+            results.extend(partial_equals_assertions.clone());
+            Some(results.into_iter().map(|v| v.to_owned()).collect())
+        } else {
+            None
+        }
+    }
+
+    fn path_assertions(&self) -> Vec<&Assertion> {
+        self.matchers
+            .iter()
+            .filter(|m| match &m {
+                Assertion::PathAssertion(_) => true,
+                Assertion::TokenAssertion(_) => false,
+            })
+            .collect::<Vec<&Assertion>>()
+    }
+
+    fn token_assertions(&self) -> Vec<&Assertion> {
+        self.matchers
+            .iter()
+            .filter(|m| match &m {
+                Assertion::TokenAssertion(_) => true,
+                Assertion::PathAssertion(_) => false,
+            })
+            .collect::<Vec<&Assertion>>()
+    }
 }
 
 impl ProjectConfiguration {
@@ -65,5 +115,89 @@ impl ProjectConfiguration {
                 .iter()
                 .any(|result| assertion.matches(result))
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::value_assertion::*;
+    use super::*;
+
+    #[test]
+    fn low_likelihood_highlights_logical_issues_with_assertions() {
+        let starts_with = ValueMatcher::StartsWith("f".to_string());
+        let ends_with = ValueMatcher::EndsWith("o".to_string());
+        let equals = ValueMatcher::Equals("foo".to_string());
+        let conflict = LowLikelihoodConfig {
+            name: String::from("Conflicting"),
+            matchers: vec![
+                Assertion::PathAssertion(starts_with.clone()),
+                Assertion::PathAssertion(equals.clone()),
+                Assertion::PathAssertion(ends_with.clone()),
+                Assertion::TokenAssertion(equals.clone()),
+            ],
+        };
+
+        assert_eq!(
+            conflict.conflicts(),
+            vec![AssertionConflict::PathConflict(vec![
+                Assertion::PathAssertion(equals),
+                Assertion::PathAssertion(starts_with),
+                Assertion::PathAssertion(ends_with)
+            ])]
+        );
+    }
+
+    #[test]
+    fn low_likelihood_highlights_multiple_logical_issues_with_assertions() {
+        let starts_with = ValueMatcher::StartsWith("f".to_string());
+        let ends_with = ValueMatcher::EndsWith("o".to_string());
+        let equals = ValueMatcher::Equals("foo".to_string());
+        let exact_match = ValueMatcher::ExactMatchOnAnyOf(
+            vec![String::from("foo"), String::from("bar")]
+                .iter()
+                .cloned()
+                .collect(),
+        );
+        let conflict = LowLikelihoodConfig {
+            name: String::from("Conflicting"),
+            matchers: vec![
+                Assertion::PathAssertion(starts_with.clone()),
+                Assertion::PathAssertion(equals.clone()),
+                Assertion::TokenAssertion(ends_with.clone()),
+                Assertion::TokenAssertion(exact_match.clone()),
+            ],
+        };
+
+        assert_eq!(
+            conflict.conflicts(),
+            vec![
+                AssertionConflict::PathConflict(vec![
+                    Assertion::PathAssertion(equals.clone()),
+                    Assertion::PathAssertion(starts_with),
+                ]),
+                AssertionConflict::TokenConflict(vec![
+                    Assertion::TokenAssertion(exact_match),
+                    Assertion::TokenAssertion(ends_with),
+                ])
+            ]
+        );
+    }
+
+    #[test]
+    fn low_likelihood_finds_no_conflicts_for_partial_equality() {
+        let starts_with = ValueMatcher::StartsWith("f".to_string());
+        let ends_with = ValueMatcher::EndsWith("o".to_string());
+        let no_conflict = LowLikelihoodConfig {
+            name: String::from("Not conflicting"),
+            matchers: vec![
+                Assertion::PathAssertion(starts_with.clone()),
+                Assertion::PathAssertion(ends_with.clone()),
+                Assertion::TokenAssertion(ends_with.clone()),
+                Assertion::TokenAssertion(starts_with.clone()),
+            ],
+        };
+
+        assert_eq!(no_conflict.conflicts(), vec![]);
     }
 }

--- a/crates/project_configuration/src/loader.rs
+++ b/crates/project_configuration/src/loader.rs
@@ -48,6 +48,23 @@ impl ProjectConfigurations {
             .map(|(_, v)| v.clone())
     }
 
+    pub fn assertion_to_key(assertion: &Assertion) -> Option<&str> {
+        match assertion {
+            Assertion::TokenAssertion(ValueMatcher::StartsWith(_)) => Some(TOKEN_STARTS_WITH),
+            Assertion::TokenAssertion(ValueMatcher::EndsWith(_)) => Some(TOKEN_ENDS_WITH),
+            Assertion::TokenAssertion(ValueMatcher::Equals(_)) => Some(TOKEN_EQUALS),
+            Assertion::TokenAssertion(ValueMatcher::ExactMatchOnAnyOf(_)) => Some(ALLOWED_TOKENS),
+            Assertion::TokenAssertion(ValueMatcher::StartsWithCapital) => Some(CLASS_OR_MODULE),
+            Assertion::TokenAssertion(ValueMatcher::Contains(_)) => None,
+            Assertion::PathAssertion(ValueMatcher::StartsWith(_)) => Some(PATH_STARTS_WITH),
+            Assertion::PathAssertion(ValueMatcher::EndsWith(_)) => Some(PATH_ENDS_WITH),
+            Assertion::PathAssertion(ValueMatcher::Equals(_)) => Some(PATH_EQUALS),
+            Assertion::PathAssertion(ValueMatcher::ExactMatchOnAnyOf(_)) => None,
+            Assertion::PathAssertion(ValueMatcher::StartsWithCapital) => None,
+            Assertion::PathAssertion(ValueMatcher::Contains(_)) => None,
+        }
+    }
+
     fn parse_all_from_yaml(contents: &[Yaml]) -> HashMap<String, ProjectConfiguration> {
         match contents {
             [Yaml::Array(items)] => items.iter().filter(|i| !i["name"].is_badvalue()).fold(

--- a/crates/project_configuration/src/value_assertion.rs
+++ b/crates/project_configuration/src/value_assertion.rs
@@ -18,6 +18,28 @@ impl Assertion {
             Assertion::TokenAssertion(matcher) => matcher.check(&token_search_result.token.token),
         }
     }
+
+    pub fn matcher(&self) -> &ValueMatcher {
+        match self {
+            Assertion::PathAssertion(matcher) => matcher,
+            Assertion::TokenAssertion(matcher) => matcher,
+        }
+    }
+}
+
+#[derive(Debug, PartialEq)]
+pub enum AssertionConflict {
+    PathConflict(Vec<Assertion>),
+    TokenConflict(Vec<Assertion>),
+}
+
+impl AssertionConflict {
+    pub fn assertions(&self) -> &Vec<Assertion> {
+        match self {
+            AssertionConflict::PathConflict(assertions) => assertions,
+            AssertionConflict::TokenConflict(assertions) => assertions,
+        }
+    }
 }
 
 #[derive(Clone, Debug, PartialEq)]
@@ -39,6 +61,14 @@ impl ValueMatcher {
             ValueMatcher::Contains(v) => haystack.contains(v),
             ValueMatcher::ExactMatchOnAnyOf(vs) => vs.contains(haystack),
             ValueMatcher::StartsWithCapital => haystack.starts_with(|v: char| v.is_uppercase()),
+        }
+    }
+
+    pub fn full_equals(&self) -> bool {
+        match self {
+            ValueMatcher::Equals(_) => true,
+            ValueMatcher::ExactMatchOnAnyOf(_) => true,
+            _ => false,
         }
     }
 }


### PR DESCRIPTION
What?
=====

Unused can be configured via .unused.yml and includes low-likelihood 
flagging that can be customized by the person using the tool.

This configuration allows for framework patterns to be skipped, helping to
slim down what unused reports as potentially deletable.

Because this can be user-configured, though, and because some of the 
filtering can conflict, it allows for logical fallacies that would render
that low-likelihood configuration useless.

First highlighted in https://github.com/unused-code/unused_rs/issues/1, the
example provided is:

```
- name: LiveView
 token_ends_with: Live
 allowed_tokens:
 - mount
 - render
 - terminate
 - handle_params
 - handle_event
 - handle_call
 - handle_info
```

In this case, token_ends_with limits low-likelihood flagging to any token
that ends with `Live`. The second constraint, captured by
`allowed_tokens`, ensures the token is an exact match of any of the items
in the list. Because of these (the exact match, and substring match), both
constraints cannot work as expected with a binary AND
(unless all of the `allowed_tokens` also ended in View, which doesn't make
sense).

At that, we highlight assertions within the low-likelihood configuration 
that conflict because of both exact and partial string matching. Multiple
partial string matches are fine, and exact/partial matching is fine if
they're on different values (tokens vs paths).

This does NOT handle this at the `Vec<Assertion>` level, as other areas of
the configuration, like determining how to classify a codebase, rely on
multiple assertions of the same type, and verify all are met somehow by
tokens in the codebase (e.g. you would have assertions to do token exact
matches for `Application` and `Repo`, among others, for a Phoenix 
application).

Resolves #4