### PR TITLE
Parse tags metadata when parsing tags file

### DIFF
--- a/crates/read_ctags/src/ctag_item.rs
+++ b/crates/read_ctags/src/ctag_item.rs
@@ -1,9 +1,11 @@
 use super::language::Language;
 use super::parser;
+use super::tags_file::TagsFile;
 use super::token_kind::TokenKind;
 use serde::Serialize;
-use std::collections::{BTreeMap, HashSet};
+use std::collections::BTreeMap;
 use std::fmt::{Display, Formatter};
+use std::path::PathBuf;
 
 /// Represents a single entry in a tags file
 #[derive(Clone, Hash, Debug, Eq, Serialize, PartialEq)]
@@ -53,9 +55,13 @@ impl Display for CtagsParseError {
 
 impl CtagItem {
     /// Parse tags generatd by Universal Ctags to generate `CtagItem`s
-    pub fn parse(input: &str) -> Result<HashSet<CtagItem>, CtagsParseError> {
+    pub fn parse(path: PathBuf, input: &str) -> Result<TagsFile, CtagsParseError> {
         match parser::parse(input) {
-            Ok(("", outcome)) => Ok(outcome),
+            Ok(("", (program, tags))) => Ok(TagsFile {
+                path,
+                program,
+                tags,
+            }),
             Ok(_) => Err(CtagsParseError::IncompleteParse),
             Err(e) => Err(CtagsParseError::FailedParse(
                 e.map(|(v1, v2)| (v1.to_string(), v2)),

--- a/crates/read_ctags/src/lib.rs
+++ b/crates/read_ctags/src/lib.rs
@@ -14,7 +14,7 @@
 //! use read_ctags::TagsReader;
 //! use serde_json;
 //! match TagsReader::default().load() {
-//!   Ok(outcome) => println!("{}", serde_json::to_string(&outcome.ctag_items).unwrap()),
+//!   Ok(outcome) => println!("{}", serde_json::to_string(&outcome.tags).unwrap()),
 //!   Err(e) => eprintln!("{}", e),
 //! }
 //! ```
@@ -22,10 +22,13 @@
 mod ctag_item;
 mod language;
 mod parser;
+mod tag_program;
+mod tags_file;
 mod tags_reader;
 mod token_kind;
 
 pub use self::ctag_item::*;
 pub use self::language::*;
+pub use self::tags_file::*;
 pub use self::tags_reader::*;
 pub use self::token_kind::*;

--- a/crates/read_ctags/src/parser/internal.rs
+++ b/crates/read_ctags/src/parser/internal.rs
@@ -1,17 +1,123 @@
+use super::TagProgram;
 use nom::{
+    branch::alt,
     bytes::complete::{tag, take_till},
+    combinator::map,
     error::ParseError,
     multi::separated_list,
-    sequence::{preceded, terminated},
+    sequence::{preceded, terminated, tuple},
     IResult,
 };
 
-pub fn tag_metadata(input: &str) -> IResult<&str, Vec<&str>> {
-    terminated(separated_list(tag("\n"), tag_annotation), tag("\n"))(input)
+enum ProgramMetadata {
+    Author(String),
+    Name(String),
+    Version(String),
+    Other,
 }
 
-fn tag_annotation(input: &str) -> IResult<&str, &str> {
-    preceded(tag("!_TAG"), to_newline)(input)
+impl ProgramMetadata {
+    fn author(&self) -> Option<String> {
+        match &self {
+            ProgramMetadata::Author(v) => Some(v.to_string()),
+            _ => None,
+        }
+    }
+
+    fn name(&self) -> Option<String> {
+        match &self {
+            ProgramMetadata::Name(v) => Some(v.to_string()),
+            _ => None,
+        }
+    }
+
+    fn version(&self) -> Option<String> {
+        match &self {
+            ProgramMetadata::Version(v) => Some(v.to_string()),
+            _ => None,
+        }
+    }
+}
+
+fn metadata_to_tag_program(metadata: Vec<ProgramMetadata>) -> TagProgram {
+    let name = metadata
+        .iter()
+        .find(|m| m.name().is_some())
+        .and_then(|m| m.name());
+    let author = metadata
+        .iter()
+        .find(|m| m.author().is_some())
+        .and_then(|m| m.author());
+    let version = metadata
+        .iter()
+        .find(|m| m.version().is_some())
+        .and_then(|m| m.version());
+
+    TagProgram {
+        name,
+        author,
+        version,
+    }
+}
+
+pub fn tag_metadata(input: &str) -> IResult<&str, TagProgram> {
+    map(
+        terminated(separated_list(tag("\n"), tag_annotation), tag("\n")),
+        metadata_to_tag_program,
+    )(input)
+}
+
+fn tag_annotation(input: &str) -> IResult<&str, ProgramMetadata> {
+    alt((program_author, program_name, program_version, program_other))(input)
+}
+
+fn tag_value<'a>(tag_name: &'a str) -> impl Fn(&'a str) -> IResult<&'a str, String> {
+    move |input| {
+        let non_commented_value = preceded(terminated(tag(tag_name), tag("\t")), to_tab);
+        map(
+            tuple((non_commented_value, metadata_comment)),
+            |(value, comment)| format!("{}{}", value, parenthetical(comment)),
+        )(input)
+    }
+}
+
+fn parenthetical(value: Option<String>) -> String {
+    match value {
+        Some(v) => format!(" ({})", v),
+        None => "".to_string(),
+    }
+}
+
+fn optional_string(input: &str) -> Option<&str> {
+    match input.trim() {
+        "" => None,
+        v => Some(v),
+    }
+}
+
+fn metadata_comment(input: &str) -> IResult<&str, Option<String>> {
+    let (input, _) = tag("/")(input)?;
+    map(terminated(take_till(|c| c == '/'), tag("/")), |v| {
+        optional_string(v).map(String::from)
+    })(input)
+}
+
+fn program_other(input: &str) -> IResult<&str, ProgramMetadata> {
+    map(preceded(tag("!_TAG"), to_newline), |_| {
+        ProgramMetadata::Other
+    })(input)
+}
+
+fn program_author(input: &str) -> IResult<&str, ProgramMetadata> {
+    map(tag_value("!_TAG_PROGRAM_AUTHOR"), ProgramMetadata::Author)(input)
+}
+
+fn program_name(input: &str) -> IResult<&str, ProgramMetadata> {
+    map(tag_value("!_TAG_PROGRAM_NAME"), ProgramMetadata::Name)(input)
+}
+
+fn program_version(input: &str) -> IResult<&str, ProgramMetadata> {
+    map(tag_value("!_TAG_PROGRAM_VERSION"), ProgramMetadata::Version)(input)
 }
 
 pub fn succeed<I: Clone, O, F: Copy + FnOnce() -> O, E: ParseError<I>>(
@@ -26,4 +132,25 @@ pub fn to_tab(input: &str) -> IResult<&str, &str> {
 
 pub fn to_newline(input: &str) -> IResult<&str, &str> {
     take_till(|c| c == '\n')(input)
+}
+
+#[test]
+fn parses_metadata_comment() {
+    assert_eq!(
+        metadata_comment("/dhiebert@users.sourceforge.net/"),
+        Ok(("", Some("dhiebert@users.sourceforge.net".to_string())))
+    );
+}
+
+#[test]
+fn parses_tag_value() {
+    assert_eq!(
+        tag_value("!_TAG_PROGRAM_AUTHOR")(
+            "!_TAG_PROGRAM_AUTHOR	Darren Hiebert	/dhiebert@users.sourceforge.net/"
+        ),
+        Ok((
+            "",
+            "Darren Hiebert (dhiebert@users.sourceforge.net)".to_string()
+        ))
+    );
 }

--- a/crates/read_ctags/src/tag_program.rs
+++ b/crates/read_ctags/src/tag_program.rs
@@ -1,0 +1,19 @@
+use serde::Serialize;
+use std::default::Default;
+
+#[derive(Debug, PartialEq, Serialize)]
+pub struct TagProgram {
+    pub name: Option<String>,
+    pub author: Option<String>,
+    pub version: Option<String>,
+}
+
+impl Default for TagProgram {
+    fn default() -> Self {
+        TagProgram {
+            name: None,
+            author: None,
+            version: None,
+        }
+    }
+}

--- a/crates/read_ctags/src/tags_file.rs
+++ b/crates/read_ctags/src/tags_file.rs
@@ -1,0 +1,15 @@
+use super::{ctag_item::CtagItem, tag_program::TagProgram};
+use serde::Serialize;
+use std::collections::HashSet;
+use std::path::PathBuf;
+
+/// Parsed tags outcome
+#[derive(Serialize)]
+pub struct TagsFile {
+    /// Path of the tags file
+    pub path: PathBuf,
+    /// Tags file program metadata
+    pub program: TagProgram,
+    /// Tags found in the tags file
+    pub tags: HashSet<CtagItem>,
+}

--- a/crates/read_ctags/src/tags_reader.rs
+++ b/crates/read_ctags/src/tags_reader.rs
@@ -1,5 +1,4 @@
-use super::{CtagItem, CtagsParseError};
-use std::collections::HashSet;
+use super::{CtagItem, CtagsParseError, TagsFile};
 use std::convert::From;
 use std::default::Default;
 use std::env::current_dir;
@@ -14,14 +13,6 @@ use std::process::Command;
 /// found
 pub struct TagsReader {
     filenames: Vec<PathBuf>,
-}
-
-/// Outcome from loading tags via TagsReader
-pub struct TagsReaderResponse {
-    /// Path to the tags file loaded
-    pub ctags_path: PathBuf,
-    /// Set of CtagItems returned
-    pub ctag_items: HashSet<CtagItem>,
 }
 
 /// A struct capturing possible failures when attempting to find and read tags files
@@ -105,14 +96,9 @@ impl Default for TagsReader {
 
 impl TagsReader {
     /// Loads and parses the first tags file it finds
-    pub fn load(&self) -> Result<TagsReaderResponse, ReadCtagsError> {
+    pub fn load(&self) -> Result<TagsFile, ReadCtagsError> {
         self.read().and_then(|(ctags_path, contents)| {
-            CtagItem::parse(&contents)
-                .map(|ctag_items| TagsReaderResponse {
-                    ctags_path,
-                    ctag_items,
-                })
-                .map_err(|e| e.into())
+            CtagItem::parse(ctags_path, &contents).map_err(|e| e.into())
         })
     }
 

--- a/crates/token_search/src/token.rs
+++ b/crates/token_search/src/token.rs
@@ -33,10 +33,10 @@ impl Token {
 
     /// Load tokens after reading tags
     pub fn all() -> Result<(PathBuf, Vec<Token>), ReadCtagsError> {
-        TagsReader::default().load().map(|res| {
+        TagsReader::default().load().map(|tags_file| {
             (
-                res.ctags_path,
-                Self::build_tokens_from_outcome(res.ctag_items),
+                tags_file.path,
+                Self::build_tokens_from_outcome(tags_file.tags),
             )
         })
     }

--- a/src/bin/read_ctags.rs
+++ b/src/bin/read_ctags.rs
@@ -3,7 +3,7 @@ use serde_json;
 
 fn main() {
     match TagsReader::default().load() {
-        Ok(outcome) => println!("{}", serde_json::to_string(&outcome.ctag_items).unwrap()),
+        Ok(outcome) => println!("{}", serde_json::to_string(&outcome).unwrap()),
         Err(e) => eprintln!("{}", e),
     }
 }


### PR DESCRIPTION
What?
=====

In addition to the tags themselves, a tags file holds information
about the program that generated it.

This updates the ctags parser to capture that information in a
structured way.

Given I don't think we can guarantee the order of metadata, it's not
clear if there's a better way to extract the tags info metadata in a
known and repeatable fashion.