### PR TITLE
Convert all uses of path_starts_with with path_contains

### DIFF
--- a/crates/project_configuration/src/default_config.yml
+++ b/crates/project_configuration/src/default_config.yml
@@ -1,8 +1,8 @@
 - name: Rails
   matches_if:
     - token_equals: ApplicationController
-    - path_starts_with: app/controllers/
-    - path_starts_with: app/models/
+    - path_contains: app/controllers/
+    - path_contains: app/models/
   application_files:
     - app/
     - lib/
@@ -27,11 +27,11 @@
       token_starts_with: test_
       path_ends_with: _tests.rb
     - name: Pundit Policies
-      path_starts_with: app/policies
+      path_contains: app/policies
       path_ends_with: _policy.rb
       token_ends_with: Policy
     - name: Pundit Policies
-      path_starts_with: app/policies
+      path_contains: app/policies
       path_ends_with: _policy.rb
       allowed_tokens:
         - new?
@@ -42,44 +42,44 @@
         - update?
         - delete?
     - name: JSONAPI::Resources
-      path_starts_with: app/resources
+      path_contains: app/resources
       path_ends_with: _resource.rb
       token_ends_with: Resource
     - name: JSONAPI::Resources Methods
-      path_starts_with: app/resources
+      path_contains: app/resources
       path_ends_with: _resource.rb
       allowed_tokens:
         - updatable_fields
         - creatable_fields
     - name: Preview
-      path_starts_with: spec/mailers
+      path_contains: spec/mailers
       token_ends_with: Preview
     - name: Migration
-      path_starts_with: db/migrate/
+      path_contains: db/migrate/
       path_ends_with: .rb
       class_or_module: true
     - name: Seed Migration
-      path_starts_with: db/data/
+      path_contains: db/data/
       path_ends_with: .rb
       class_or_module: true
     - name: Migration
-      path_starts_with: db/archived_migrate/
+      path_contains: db/archived_migrate/
       path_ends_with: .rb
       class_or_module: true
     - name: Controller
-      path_starts_with: app/controllers/
+      path_contains: app/controllers/
       path_ends_with: .rb
       token_ends_with: Controller
     - name: Model
-      path_starts_with: app/models/
+      path_contains: app/models/
       path_ends_with: .rb
       class_or_module: true
     - name: Helper
-      path_starts_with: app/helpers/
+      path_contains: app/helpers/
       path_ends_with: .rb
       class_or_module: true
     - name: Clearance helpers
-      path_starts_with: app/controllers/
+      path_contains: app/controllers/
       path_ends_with: .rb
       allowed_tokens:
         - url_after_create
@@ -87,7 +87,7 @@
         - after_sign_in_path_for
         - after_sign_out_path_for
     - name: GraphQL Helpers
-      path_starts_with: app/graphql/
+      path_contains: app/graphql/
       path_ends_with: .rb
       allowed_tokens:
         - BaseEnum
@@ -98,15 +98,15 @@
         - resolve_field
         - object_from_id
     - name: ActiveModel Validators
-      path_starts_with: app/validators/
+      path_contains: app/validators/
       path_ends_with: .rb
       token_ends_with: Validator
     - name: SimpleForm Input
-      path_starts_with: app/inputs/
+      path_contains: app/inputs/
       path_ends_with: .rb
       token_ends_with: Input
     - name: RSpec Methods
-      path_starts_with: spec/
+      path_contains: spec/
       path_ends_with: .rb
       allowed_tokens:
         - post_processing
@@ -135,11 +135,11 @@
         - MixProject
     - name: Tests
       token_ends_with: Test
-      path_starts_with: test/
+      path_contains: test/
       path_ends_with: _test.exs
     - name: Migrations
       class_or_module: true
-      path_starts_with: priv/repo/migrations
+      path_contains: priv/repo/migrations
       path_ends_with: .exs
     - name: Views
       token_ends_with: View

--- a/crates/project_configuration/src/loader.rs
+++ b/crates/project_configuration/src/loader.rs
@@ -8,15 +8,17 @@ use yaml_rust::{Yaml, YamlLoader};
 const PATH_STARTS_WITH: &str = "path_starts_with";
 const PATH_ENDS_WITH: &str = "path_ends_with";
 const PATH_EQUALS: &str = "path_equals";
+const PATH_CONTAINS: &str = "path_contains";
 const TOKEN_EQUALS: &str = "token_equals";
 const TOKEN_STARTS_WITH: &str = "token_starts_with";
 const TOKEN_ENDS_WITH: &str = "token_ends_with";
 const CLASS_OR_MODULE: &str = "class_or_module";
 const ALLOWED_TOKENS: &str = "allowed_tokens";
-const SUPPORTED_ASSERTIONS: [&'static str; 8] = [
+const SUPPORTED_ASSERTIONS: [&'static str; 9] = [
     PATH_STARTS_WITH,
     PATH_ENDS_WITH,
     PATH_EQUALS,
+    PATH_CONTAINS,
     TOKEN_EQUALS,
     TOKEN_STARTS_WITH,
     TOKEN_ENDS_WITH,
@@ -70,7 +72,7 @@ impl ProjectConfigurations {
             Assertion::PathAssertion(ValueMatcher::Equals(_)) => Some(PATH_EQUALS),
             Assertion::PathAssertion(ValueMatcher::ExactMatchOnAnyOf(_)) => None,
             Assertion::PathAssertion(ValueMatcher::StartsWithCapital) => None,
-            Assertion::PathAssertion(ValueMatcher::Contains(_)) => None,
+            Assertion::PathAssertion(ValueMatcher::Contains(_)) => Some(PATH_CONTAINS),
         }
     }
 
@@ -185,6 +187,9 @@ impl ProjectConfigurations {
             PATH_EQUALS => Some(Assertion::PathAssertion(ValueMatcher::Equals(
                 val.to_string(),
             ))),
+            PATH_CONTAINS => Some(Assertion::PathAssertion(ValueMatcher::Contains(
+                val.to_string(),
+            ))),
             TOKEN_STARTS_WITH => Some(Assertion::TokenAssertion(ValueMatcher::StartsWith(
                 val.to_string(),
             ))),
@@ -269,7 +274,7 @@ mod tests {
       path_ends_with: .rb
     - name: JSONAPI::Resources
       token_ends_with: Resource
-      path_starts_with: app/resources
+      path_contains: app/resources
 "
         .to_string()
     }
@@ -340,9 +345,7 @@ mod tests {
             &LowLikelihoodConfig {
                 name: String::from("JSONAPI::Resources"),
                 matchers: vec![
-                    Assertion::PathAssertion(ValueMatcher::StartsWith(String::from(
-                        "app/resources"
-                    ))),
+                    Assertion::PathAssertion(ValueMatcher::Contains(String::from("app/resources"))),
                     Assertion::TokenAssertion(ValueMatcher::EndsWith(String::from("Resource"))),
                 ]
             }


### PR DESCRIPTION
What?
=====

This updates path checking with default configuration to match paths
that contain certain structures rather than explicitly begin with
structures.

This is meant to allow for consistent path checking without enforcing
the path actually match from the beginning. This comes up most
frequently where monoliths actually contain multiple applications within
them.