### PR TITLE
Allow for overriding project type

### DIFF
--- a/crates/cli/src/flags.rs
+++ b/crates/cli/src/flags.rs
@@ -71,6 +71,14 @@ pub struct Flags {
     #[structopt(long, use_delimiter = true)]
     pub ignore: Vec<String>,
 
+    /// Project type configuration
+    ///
+    /// By default, unused will attempt to detect the type of project you're working on based on
+    /// heuristics on file or token detection. Setting this will override behavior. If the project
+    /// type is not found, unused will fallback to default settings (rather than best match).
+    #[structopt(long)]
+    pub project_type: Option<String>,
+
     #[structopt(subcommand)]
     pub cmd: Option<Command>,
 }

--- a/crates/cli/src/formatters/standard.rs
+++ b/crates/cli/src/formatters/standard.rs
@@ -65,7 +65,7 @@ fn usage_summary(tokens_count: usize, files_count: usize, cli_config: &CliConfig
         cli_config.usage_likelihood_filter().join(", ").cyan()
     );
     println!(
-        "   Configuration setting: {}",
+        "   Project type configuration: {}",
         cli_config.configuration_name().cyan()
     );
     println!("");


### PR DESCRIPTION
What?
=====

Because unused may not (by default) be able to determine the best match
project type, this opens up a flag to set this by hand.

In doing so, this also improves the messaging around project type
configuration in standard mode.