### PR TITLE
Replace dirs with dirs-next

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -92,6 +92,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b486ce3ccf7ffd79fdeb678eac06a9e6c09fc88d33836340becb8fffe87c5e33"
 
 [[package]]
+name = "cfg-if"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
 name = "clap"
 version = "2.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -112,7 +118,7 @@ version = "0.1.0"
 dependencies = [
  "codebase_files",
  "colored",
- "dirs",
+ "dirs-next",
  "itertools",
  "project_configuration",
  "read_ctags",
@@ -198,7 +204,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "058ed274caafc1f60c4997b5fc07bf7dc7cca454af7c6e81edffe5f33f70dace"
 dependencies = [
  "autocfg",
- "cfg-if",
+ "cfg-if 0.1.9",
  "crossbeam-utils",
  "lazy_static",
  "maybe-uninit",
@@ -212,7 +218,7 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c695eeca1e7173472a32221542ae469b3e9aac3a4fc81f7696bcad82029493db"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.9",
  "crossbeam-utils",
 ]
 
@@ -223,27 +229,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3c7c73a2d1e9fc0886a08b93e98eb643461230d5f1925e4036204d5f2e261a8"
 dependencies = [
  "autocfg",
- "cfg-if",
+ "cfg-if 0.1.9",
  "lazy_static",
 ]
 
 [[package]]
-name = "dirs"
-version = "2.0.2"
+name = "dirs-next"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13aea89a5c93364a98e9b37b2fa237effbb694d5cfe01c5b70941f7eb087d5e3"
+checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
 dependencies = [
- "cfg-if",
- "dirs-sys",
+ "cfg-if 1.0.0",
+ "dirs-sys-next",
 ]
 
 [[package]]
-name = "dirs-sys"
-version = "0.3.4"
+name = "dirs-sys-next"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afa0b23de8fd801745c471deffa6e12d248f962c9fd4b4c33787b055599bde7b"
+checksum = "99de365f605554ae33f115102a02057d4fc18b01f3284d6870be0938743cfe7d"
 dependencies = [
- "cfg-if",
  "libc",
  "redox_users",
  "winapi",
@@ -267,7 +272,7 @@ version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7abc8dd8451921606d809ba32e95b6111925cd2906060d2dcc29c070220503eb"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.9",
  "libc",
  "wasi",
 ]
@@ -332,7 +337,7 @@ checksum = "f86d66d380c9c5a685aaac7a11818bdfa1f733198dfd9ec09c70b762cd12ad6f"
 dependencies = [
  "arrayvec 0.4.12",
  "bitflags",
- "cfg-if",
+ "cfg-if 0.1.9",
  "rustc_version",
  "ryu",
  "static_assertions",
@@ -461,7 +466,6 @@ dependencies = [
 name = "project_configuration"
 version = "0.1.0"
 dependencies = [
- "dirs",
  "token_search",
  "totems",
  "yaml-rust",

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -13,5 +13,5 @@ token_analysis = { path = "../../crates/token_analysis/" }
 project_configuration = { path = "../../crates/project_configuration/" }
 colored = "1.9.3"
 itertools = "0.9"
-dirs = "2.0"
+dirs-next = "2.0"
 structopt = "0.3"

--- a/crates/cli/src/project_configurations_loader.rs
+++ b/crates/cli/src/project_configurations_loader.rs
@@ -1,4 +1,4 @@
-use dirs;
+use dirs_next;
 use project_configuration::ProjectConfigurations;
 use std::fs;
 use std::io;
@@ -12,7 +12,8 @@ pub fn load_and_parse_config() -> ProjectConfigurations {
 }
 
 fn file_path_in_home_dir(file_name: &str) -> Option<String> {
-    dirs::home_dir().and_then(|ref p| Path::new(p).join(file_name).to_str().map(|v| v.to_owned()))
+    dirs_next::home_dir()
+        .and_then(|ref p| Path::new(p).join(file_name).to_str().map(|v| v.to_owned()))
 }
 
 fn read_file(filename: &str) -> Result<String, io::Error> {

--- a/crates/project_configuration/Cargo.toml
+++ b/crates/project_configuration/Cargo.toml
@@ -9,7 +9,6 @@ license = "MIT"
 
 [dependencies]
 yaml-rust = "0.4"
-dirs = "2.0"
 token_search = { path = "../../crates/token_search" }
 
 [dev-dependencies]


### PR DESCRIPTION
What?
=====

This updates the dependency from dirs to dirs-next when calculating the
home directory for unused configuration storage.

Closes #20