### PR TITLE
Add a README section on Nix

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,21 @@ brew update
 brew upgrade unused
 ```
 
+### Nix
+
+There is a [Nix] expression [available in nixpkgs].
+
+There are many ways to run `unused` with Nix, but the simplest is:
+
+```sh
+nix run -f https://github.com/NixOS/nixpkgs/archive/nixpkgs-unstable.zip unused -c unused --help
+```
+
+Everything after `-c` is treated as a command and its arguments.
+
+[nix]: https://nixos.org
+[available in nixpkgs]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/development/tools/misc/unused/default.nix
+
 ## Prerequisites
 
 It is strongly recommended you install [Universal Ctags] to generate tags


### PR DESCRIPTION
There are many ways someone could use the expression in nixpkgs, so I've chosen the simplest possible thing to do: just run `unused`. I hope this provides enough information for someone to use nix-channel and nix-env, or home-manager, or configuration.nix, or their own expression, etc.