### PR TITLE
nix run -> nix-shell

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,10 +43,8 @@ There is a [Nix] expression [available in nixpkgs].
 There are many ways to run `unused` with Nix, but the simplest is:
 
 ```sh
-nix run -f https://github.com/NixOS/nixpkgs/archive/nixpkgs-unstable.zip unused -c unused --help
+nix-shell -I nixpkgs=https://github.com/NixOS/nixpkgs/archive/nixpkgs-unstable.tar.gz -p unused --run 'unused --help'
 ```
-
-Everything after `-c` is treated as a command and its arguments.
 
 [nix]: https://nixos.org
 [available in nixpkgs]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/development/tools/misc/unused/default.nix


### PR DESCRIPTION
`nix-shell` is currently the recommended tool for ad-hoc shells, not `nix run`.

See https://github.com/unused-code/unused/pull/26#discussion_r548000038