### PR TITLE
Make mimalloc optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ read_ctags = { path = "crates/read_ctags/" }
 token_search = { path = "crates/token_search/" }
 codebase_files = { path = "crates/codebase_files/" }
 cli = { path = "crates/cli/" }
-mimalloc = { version = "*", default-features = false }
+mimalloc = { version = "*", default-features = false, optional = true }
 
 [[bin]]
 name = "read-ctags-rs"

--- a/src/bin/unused.rs
+++ b/src/bin/unused.rs
@@ -1,4 +1,4 @@
-#[cfg(all(unix, not(target_env = "musl")))]
+#[cfg(all(feature = "mimalloc", unix, not(target_env = "musl")))]
 #[global_allocator]
 static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
 


### PR DESCRIPTION
What?
=====

mimalloc significantly reduces execution time in local benchmarking, but
may be causing problems with ARM architectures (specifically the MBP
M1s).

This shifts mimalloc from a hard dependency to a feature flag which can
be configured during install.