### PR TITLE
update lexical-core because 0.7.4 doesn't compile

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -337,13 +337,13 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "lexical-core"
-version = "0.7.4"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db65c6da02e61f55dae90a0ae427b2a5f6b3e8db09f58d10efab23af92592616"
+checksum = "6607c62aa161d23d17a9072cc5da0be67cdfc89d3afb1e8d9c842bebc2525ffe"
 dependencies = [
  "arrayvec",
  "bitflags",
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "ryu",
  "static_assertions",
 ]


### PR DESCRIPTION
My attempt at `brew install unused` ended up here:

```
==> Installing unused-code/formulae/unused
==> cargo install --features mimalloc
Last 15 lines from /Users/mackenziemorgan/Library/Logs/Homebrew/unused/01.cargo:
     |
     = help: the trait `Sub<usize>` is not implemented for `u32`

error: aborting due to 27 previous errors

Some errors have detailed explanations: E0277, E0308.
For more information about an error, try `rustc --explain E0277`.
error: could not compile `lexical-core`

To learn more, run the command again with --verbose.
warning: build failed, waiting for other jobs to finish...
error: failed to compile `unused v0.2.2 (/private/tmp/unused-20210623-192-1ubmnuk/unused-0.2.2)`, intermediate artifacts can be found at `/private/tmp/unused-20210623-192-1ubmnuk/unused-0.2.2/target`

Caused by:
  build failed

If reporting this issue please do so at (not Homebrew/brew or Homebrew/core):
  https://github.com/unused-code/homebrew-formulae/issues

```

which is very sad. Googling around, I found out [lexical-core 0.7.5 fixes the trait thing it's complaining about](https://github.com/rust-lang/rust/issues/81654#issuecomment-778564715), so I'm hoping that fully updating this dependency will make unused compilable again.
