### PR TITLE
Add `--harsh` to return an exit status of 1 when tokens are found

### DIFF
--- a/crates/cli/src/flags.rs
+++ b/crates/cli/src/flags.rs
@@ -71,6 +71,10 @@ pub struct Flags {
     #[structopt(long, use_delimiter = true)]
     pub ignore: Vec<String>,
 
+    /// Return an exit status of 1 if any tokens are found
+    #[structopt(long)]
+    pub harsh: bool,
+
     #[structopt(subcommand)]
     pub cmd: Option<Command>,
 }

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -11,6 +11,7 @@ use colored::*;
 use doctor::Doctor;
 use flags::{Flags, Format};
 use project_configuration::ProjectConfigurations;
+use std::process;
 use structopt::StructOpt;
 use token_search::Token;
 
@@ -29,7 +30,16 @@ pub fn run() {
         Some(flags::Command::Doctor) => Doctor::new().render(),
         Some(flags::Command::DefaultYaml) => println!("{}", ProjectConfigurations::default_yaml()),
         _ => match Token::all() {
-            Ok((_, results)) => CliConfiguration::new(&flags, results).render(),
+            Ok((_, results)) => {
+                if results.is_empty() {
+                    CliConfiguration::new(&flags, vec![]).render()
+                } else {
+                    CliConfiguration::new(&flags, results).render();
+                    if flags.harsh {
+                        process::exit(1);
+                    }
+                }
+            }
             Err(e) => error_message::failed_token_parse(e),
         },
     }


### PR DESCRIPTION
What?
=====

It is currently difficult to use unused in CI processes (assuming you
want to fail the build if any tokens are found) because, even when
tokens are found, unused returns a 0 exit status.

This introduces a new flag, `--harsh`, which will return an exit status
of 1 if any tokens are found during a typical run (e.g. not during
`unused doctor` and other commands).

This behavior may be inverted in the future such that standard runs
will, by default, return an exit status of 1 without the flag.

Resolves #22