### PR TITLE
Update old program names to remove the '-rs' suffix

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,15 +20,15 @@ assert_fs = "1.0"
 predicates = "2.1"
 
 [[bin]]
-name = "read-ctags-rs"
+name = "read-ctags"
 path = "src/bin/read_ctags.rs"
 
 [[bin]]
-name = "token-search-rs"
+name = "token-search"
 path = "src/bin/token_search.rs"
 
 [[bin]]
-name = "tracked-files-rs"
+name = "tracked-files"
 path = "src/bin/codebase_files.rs"
 
 [[bin]]

--- a/crates/cli/src/flags.rs
+++ b/crates/cli/src/flags.rs
@@ -14,7 +14,7 @@ pub enum Command {
 
 #[derive(Debug, StructOpt)]
 #[structopt(
-    name = "unused-rs",
+    name = "unused",
     about = "A command line tool to identify potentially unused code",
     setting = structopt::clap::AppSettings::ColoredHelp
 )]


### PR DESCRIPTION
What?
=====

When unused was rewritten in Rust (previously in Haskell: https://github.com/joshuaclayton/unused), binaries generated included the '-rs' suffix to differentiate from the Haskell versions.

Now that the rewrite is complete, references to each of the generated binaries can be updated to remove the suffix.