### PR TITLE
Introduce new CLI flag allowing for overriding the tags file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,6 +27,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
 
 [[package]]
+name = "assert_cmd"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e996dc7940838b7ef1096b882e29ec30a3149a3a443cdc8dba19ed382eca1fe2"
+dependencies = [
+ "bstr",
+ "doc-comment",
+ "predicates",
+ "predicates-core",
+ "predicates-tree",
+ "wait-timeout",
+]
+
+[[package]]
+name = "assert_fs"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "633ff1df0788db09e2087fb93d05974e93acb886ac3aec4e67be1d6932e360e4"
+dependencies = [
+ "doc-comment",
+ "globwalk",
+ "predicates",
+ "predicates-core",
+ "predicates-tree",
+ "tempfile",
+]
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -55,7 +83,9 @@ version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "473fc6b38233f9af7baa94fb5852dca389e3d95b8e21c8e3719301462c5d9faf"
 dependencies = [
+ "lazy_static",
  "memchr",
+ "regex-automata",
 ]
 
 [[package]]
@@ -98,7 +128,7 @@ dependencies = [
  "codebase_files",
  "colored",
  "dirs-next",
- "itertools",
+ "itertools 0.9.0",
  "project_configuration",
  "read_ctags",
  "serde_json",
@@ -203,6 +233,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "difflib"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
+
+[[package]]
 name = "dirs-next"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -224,6 +260,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "doc-comment"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
+
+[[package]]
 name = "either"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -234,6 +276,15 @@ name = "encode_unicode"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
+
+[[package]]
+name = "float-cmp"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98de4bbd547a563b716d8dfa9aad1cb19bfab00f4fa09a6a4ed21dbcf44ce9c4"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "fnv"
@@ -249,7 +300,18 @@ checksum = "fc587bc0ec293155d5bfa6b9891ec18a1e330c234f896ea47fbada4cadbe47e6"
 dependencies = [
  "cfg-if 0.1.10",
  "libc",
- "wasi",
+ "wasi 0.9.0+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fcd999463524c52659517fe2cea98493cfe485d10565e7b0fb07dbba7ad2753"
+dependencies = [
+ "cfg-if 1.0.0",
+ "libc",
+ "wasi 0.10.2+wasi-snapshot-preview1",
 ]
 
 [[package]]
@@ -263,6 +325,17 @@ dependencies = [
  "fnv",
  "log",
  "regex",
+]
+
+[[package]]
+name = "globwalk"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93e3af942408868f6934a7b85134a3230832b9977cf66125df2f9edcfce4ddcc"
+dependencies = [
+ "bitflags",
+ "ignore",
+ "walkdir",
 ]
 
 [[package]]
@@ -319,6 +392,15 @@ name = "itertools"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "284f18f85651fe11e8a991b2adb42cb078325c996ed026d994719efcfca1d54b"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9a9d19fa1e79b6215ff29b9d6880b706147f16e9b1dbb1e4e5947b5b02bc5e3"
 dependencies = [
  "either",
 ]
@@ -414,6 +496,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "normalize-line-endings"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
+
+[[package]]
+name = "num-traits"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "num_cpus"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -434,6 +531,42 @@ name = "once_cell"
 version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13bd41f508810a131401606d54ac32a467c97172d74ba7662562ebba5ad07fa0"
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
+
+[[package]]
+name = "predicates"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95e5a7689e456ab905c22c2b48225bb921aba7c8dfa58440d68ba13f6222a715"
+dependencies = [
+ "difflib",
+ "float-cmp",
+ "itertools 0.10.3",
+ "normalize-line-endings",
+ "predicates-core",
+ "regex",
+]
+
+[[package]]
+name = "predicates-core"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57e35a3326b75e49aa85f5dc6ec15b41108cf5aee58eabb1f274dd18b73c2451"
+
+[[package]]
+name = "predicates-tree"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "338c7be2905b732ae3984a2f40032b5e94fd8f52505b186c7d4d68d193445df7"
+dependencies = [
+ "predicates-core",
+ "termtree",
+]
 
 [[package]]
 name = "proc-macro-error"
@@ -487,6 +620,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e7573632e6454cf6b99d7aac4ccca54be06da05aca2ef7423d22d27d4d4bcd8"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+ "rand_hc",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
+dependencies = [
+ "getrandom 0.2.3",
+]
+
+[[package]]
+name = "rand_hc"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d51e9f596de227fda2ea6c84607f5558e196eeaf43c986b724ba4fb8fdf497e7"
+dependencies = [
+ "rand_core",
+]
+
+[[package]]
 name = "rayon"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -528,13 +701,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41cc0f7e4d5d4544e8861606a285bb08d3e70712ccc7d2b84d7c0ccfaf4b05ce"
 
 [[package]]
+name = "redox_syscall"
+version = "0.2.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8383f39639269cde97d255a32bdb68c047337295414940c68bdd30c2e13203ff"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "redox_users"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de0737333e7a9502c789a36d7c7fa6092a49895d4faa31ca5df163857ded2e9d"
 dependencies = [
- "getrandom",
- "redox_syscall",
+ "getrandom 0.1.15",
+ "redox_syscall 0.1.57",
 ]
 
 [[package]]
@@ -550,10 +732,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex-automata"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+
+[[package]]
 name = "regex-syntax"
 version = "0.6.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b181ba2dcf07aaccad5448e8ead58db5b742cf85dfe035e2227f137a539a189"
+
+[[package]]
+name = "remove_dir_all"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "ryu"
@@ -655,6 +852,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempfile"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dac1c663cfc93810f88aed9b8941d48cabf856a1b111c29a40439018d870eb22"
+dependencies = [
+ "cfg-if 1.0.0",
+ "libc",
+ "rand",
+ "redox_syscall 0.2.10",
+ "remove_dir_all",
+ "winapi",
+]
+
+[[package]]
 name = "terminal_size"
 version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -663,6 +874,12 @@ dependencies = [
  "libc",
  "winapi",
 ]
+
+[[package]]
+name = "termtree"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13a4ec180a2de59b57434704ccfad967f789b12737738798fa08798cd5824c16"
 
 [[package]]
 name = "textwrap"
@@ -687,7 +904,7 @@ name = "token_analysis"
 version = "0.1.0"
 dependencies = [
  "indicatif",
- "itertools",
+ "itertools 0.9.0",
  "project_configuration",
  "rayon",
  "read_ctags",
@@ -704,7 +921,7 @@ dependencies = [
  "aho-corasick",
  "codebase_files",
  "indicatif",
- "itertools",
+ "itertools 0.9.0",
  "nom",
  "rayon",
  "read_ctags",
@@ -740,9 +957,12 @@ checksum = "f7fe0bb3479651439c9112f72b6c505038574c9fbb575ed1bf3b797fa39dd564"
 name = "unused"
 version = "0.3.1"
 dependencies = [
+ "assert_cmd",
+ "assert_fs",
  "cli",
  "codebase_files",
  "mimalloc",
+ "predicates",
  "read_ctags",
  "serde_json",
  "token_search",
@@ -761,6 +981,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5a972e5669d67ba988ce3dc826706fb0a8b01471c088cb0b6110b805cc36aed"
 
 [[package]]
+name = "wait-timeout"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "walkdir"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -776,6 +1005,12 @@ name = "wasi"
 version = "0.9.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
+
+[[package]]
+name = "wasi"
+version = "0.10.2+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
 
 [[package]]
 name = "winapi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,11 @@ codebase_files = { path = "crates/codebase_files/" }
 cli = { path = "crates/cli/" }
 mimalloc = { version = "*", default-features = false, optional = true }
 
+[dev-dependencies]
+assert_cmd = "2.0"
+assert_fs = "1.0"
+predicates = "2.1"
+
 [[bin]]
 name = "read-ctags-rs"
 path = "src/bin/read_ctags.rs"

--- a/crates/cli/src/doctor.rs
+++ b/crates/cli/src/doctor.rs
@@ -10,19 +10,20 @@ use super::doctor::{
     tags_included_in_files_searched::*, tokens_count::*, using_universal_ctags::*,
 };
 use colored::*;
+use read_ctags::TagsReader;
 
 pub struct Doctor {
     checks: Vec<Box<dyn CheckUp>>,
 }
 
 impl Doctor {
-    pub fn new() -> Self {
+    pub fn new(tags_reader: &TagsReader) -> Self {
         Self {
             checks: vec![
-                Box::new(IncludingTagsInFilesSearched::new()),
-                Box::new(TokensCount::new()),
+                Box::new(IncludingTagsInFilesSearched::new(tags_reader)),
+                Box::new(TokensCount::new(tags_reader)),
                 Box::new(FilesCount::new()),
-                Box::new(UsingUniversalCtags::new()),
+                Box::new(UsingUniversalCtags::new(tags_reader)),
                 Box::new(LoadedProjectConfigurations::new()),
             ],
         }

--- a/crates/cli/src/doctor/tags_included_in_files_searched.rs
+++ b/crates/cli/src/doctor/tags_included_in_files_searched.rs
@@ -1,5 +1,6 @@
 use super::check_up::{CheckUp, Status};
 use codebase_files::CodebaseFiles;
+use read_ctags::TagsReader;
 use std::path::PathBuf;
 use token_search::Token;
 
@@ -12,8 +13,8 @@ pub enum IncludingTagsInFilesSearched {
 }
 
 impl IncludingTagsInFilesSearched {
-    pub fn new() -> Self {
-        match Token::all() {
+    pub fn new(tags_reader: &TagsReader) -> Self {
+        match Token::all(tags_reader) {
             Ok((ctags_path, _)) => IncludingTagsInFilesSearched::Success {
                 files_searched: CodebaseFiles::all().paths,
                 ctags_path,

--- a/crates/cli/src/doctor/tokens_count.rs
+++ b/crates/cli/src/doctor/tokens_count.rs
@@ -1,4 +1,5 @@
 use super::check_up::{CheckUp, Status};
+use read_ctags::TagsReader;
 use token_search::Token;
 
 pub enum TokensCount {
@@ -7,8 +8,8 @@ pub enum TokensCount {
 }
 
 impl TokensCount {
-    pub fn new() -> Self {
-        match Token::all() {
+    pub fn new(tags_reader: &TagsReader) -> Self {
+        match Token::all(tags_reader) {
             Ok((_, results)) => Self::Success(results.len()),
             Err(e) => Self::Failure(format!("{}", e)),
         }

--- a/crates/cli/src/doctor/using_universal_ctags.rs
+++ b/crates/cli/src/doctor/using_universal_ctags.rs
@@ -4,8 +4,8 @@ use read_ctags::TagsReader;
 pub struct UsingUniversalCtags(Option<String>);
 
 impl UsingUniversalCtags {
-    pub fn new() -> Self {
-        match TagsReader::default().load() {
+    pub fn new(tags_reader: &TagsReader) -> Self {
+        match tags_reader.load() {
             Ok(outcome) => Self(outcome.program.name),
             Err(_) => Self(None),
         }

--- a/crates/cli/src/flags.rs
+++ b/crates/cli/src/flags.rs
@@ -1,5 +1,5 @@
 use read_ctags::Language;
-use std::str::FromStr;
+use std::{path::PathBuf, str::FromStr};
 use structopt::StructOpt;
 use token_analysis::{OrderField, UsageLikelihoodStatus};
 
@@ -74,6 +74,10 @@ pub struct Flags {
     /// Return an exit status of 1 if any tokens are found
     #[structopt(long)]
     pub harsh: bool,
+
+    /// Override path to tags file
+    #[structopt(long, short = "t", parse(from_os_str))]
+    pub tags_file_path: Option<PathBuf>,
 
     #[structopt(subcommand)]
     pub cmd: Option<Command>,

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -11,6 +11,7 @@ use colored::*;
 use doctor::Doctor;
 use flags::{Flags, Format};
 use project_configuration::ProjectConfigurations;
+use read_ctags::TagsReader;
 use std::process;
 use structopt::StructOpt;
 use token_search::Token;
@@ -26,10 +27,15 @@ pub fn run() {
         control::set_override(false);
     }
 
+    let mut tags_reader = TagsReader::default();
+    if let Some(tags_file_path) = &flags.tags_file_path {
+        tags_reader.for_tags_file(tags_file_path.to_path_buf());
+    }
+
     match flags.cmd {
-        Some(flags::Command::Doctor) => Doctor::new().render(),
+        Some(flags::Command::Doctor) => Doctor::new(&tags_reader).render(),
         Some(flags::Command::DefaultYaml) => println!("{}", ProjectConfigurations::default_yaml()),
-        None => match Token::all() {
+        None => match Token::all(&tags_reader) {
             Ok((_, results)) => {
                 let configuration = CliConfiguration::new(&flags, results);
                 configuration.render();

--- a/crates/read_ctags/src/tags_reader.rs
+++ b/crates/read_ctags/src/tags_reader.rs
@@ -107,6 +107,12 @@ impl TagsReader {
         })
     }
 
+    /// Override the default set of paths with a user-provided one
+    pub fn for_tags_file(&mut self, path: PathBuf) -> &mut Self {
+        self.filenames = vec![path];
+        self
+    }
+
     fn read(&self) -> Result<(PathBuf, String), ReadCtagsError> {
         Self::first_success(
             &self.filenames,

--- a/crates/token_search/src/token.rs
+++ b/crates/token_search/src/token.rs
@@ -31,8 +31,8 @@ impl Token {
     }
 
     /// Load tokens after reading tags
-    pub fn all() -> Result<(PathBuf, Vec<Token>), ReadCtagsError> {
-        TagsReader::default().load().map(|tags_file| {
+    pub fn all(tags_reader: &TagsReader) -> Result<(PathBuf, Vec<Token>), ReadCtagsError> {
+        tags_reader.load().map(|tags_file| {
             (
                 tags_file.path,
                 Self::build_tokens_from_outcome(tags_file.tags),

--- a/src/bin/token_search.rs
+++ b/src/bin/token_search.rs
@@ -1,7 +1,9 @@
+use read_ctags::TagsReader;
 use token_search::{Token, TokenSearchConfig, TokenSearchResults};
 
 fn main() {
-    match Token::all() {
+    let tags_reader = TagsReader::default();
+    match Token::all(&tags_reader) {
         Ok((_, outcome)) => {
             let mut config = TokenSearchConfig::default();
             config.tokens = outcome;

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1,0 +1,58 @@
+use assert_cmd::prelude::*; // Add methods on commands
+use assert_fs::{prelude::*, NamedTempFile};
+use predicates::prelude::*; // Used for writing assertions
+use std::process::Command; // Run programs
+
+#[test]
+fn doctor_works() -> Result<(), Box<dyn std::error::Error>> {
+    let (_file, mut cmd) = configure_command_with_tags_file_override()?;
+
+    cmd.arg("doctor");
+
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::contains("Unused Doctor"))
+        .stdout(predicate::str::contains(
+            "Are tokens found in the application?",
+        ));
+
+    Ok(())
+}
+
+#[test]
+fn harsh_triggers_failure() -> Result<(), Box<dyn std::error::Error>> {
+    let (_file, mut cmd) = configure_command_with_tags_file_override()?;
+
+    cmd.arg("-a");
+    cmd.arg("--harsh");
+
+    cmd.assert()
+        .failure()
+        .stdout(predicate::str::contains("Tokens found:"));
+
+    Ok(())
+}
+
+#[test]
+fn token_search_successful() -> Result<(), Box<dyn std::error::Error>> {
+    let (_file, mut cmd) = configure_command_with_tags_file_override()?;
+
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::contains("Tokens found:"));
+
+    Ok(())
+}
+
+fn configure_command_with_tags_file_override(
+) -> Result<(NamedTempFile, Command), Box<dyn std::error::Error>> {
+    let mut cmd = Command::cargo_bin("unused")?;
+    let file = assert_fs::NamedTempFile::new("tags")?;
+    file.write_str("Alias	../crates/read_ctags/src/token_kind.rs	/^    Alias,$/;\"	e	enum:TokenKind")?;
+
+    let path = file.path().display().to_string();
+    cmd.arg("-t");
+    cmd.arg(path);
+
+    Ok((file, cmd))
+}


### PR DESCRIPTION
What?
=====

This updates the CLI by introducing a new flag, `--tags-file-path` (or `-t`), to configure the path to the tags file being searched.

Resolves #28