### PR TITLE
Update necessary versions of each crate and CLI tool

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -123,7 +123,7 @@ dependencies = [
 
 [[package]]
 name = "cli"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "codebase_files",
  "colored",
@@ -686,7 +686,7 @@ dependencies = [
 
 [[package]]
 name = "read_ctags"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "nom",
  "serde",
@@ -916,7 +916,7 @@ dependencies = [
 
 [[package]]
 name = "token_search"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "aho-corasick",
  "codebase_files",
@@ -955,7 +955,7 @@ checksum = "f7fe0bb3479651439c9112f72b6c505038574c9fbb575ed1bf3b797fa39dd564"
 
 [[package]]
 name = "unused"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "assert_cmd",
  "assert_fs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "unused"
-version = "0.3.1"
+version = "0.4.0"
 authors = ["Joshua Clayton <joshua.clayton@gmail.com>"]
 edition = "2018"
 

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cli"
-version = "0.3.1"
+version = "0.4.0"
 authors = ["Joshua Clayton <joshua.clayton@gmail.com>"]
 edition = "2018"
 

--- a/crates/read_ctags/Cargo.toml
+++ b/crates/read_ctags/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "read_ctags"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Joshua Clayton <joshua.clayton@gmail.com>"]
 edition = "2018"
 license = "MIT"

--- a/crates/token_search/Cargo.toml
+++ b/crates/token_search/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "token_search"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Joshua Clayton <joshua.clayton@gmail.com>"]
 edition = "2018"
 license = "MIT"


### PR DESCRIPTION
What?
=====

With changes to each of the CLI, read_ctags, and token_search crates to
accommodate changes introduced in 22b4c2273545ffc013986769314f72d0aefd9fd1.