### PR TITLE
feat: Add method aliases

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -271,9 +271,9 @@ dependencies = [
 
 [[package]]
 name = "convert_case"
-version = "0.8.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baaaa0ecca5b51987b9423ccdc971514dd8b0bb7b4060b983d3664dad3f1f89f"
+checksum = "affbf0190ed2caf063e3def54ff444b449371d55c58e513a95ab98eca50adb49"
 dependencies = [
  "unicode-segmentation",
 ]
@@ -737,7 +737,6 @@ dependencies = [
  "proptest",
  "serde",
  "serde_yaml",
- "tempfile",
  "token_search",
  "totems",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -56,7 +56,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -67,8 +67,14 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
+
+[[package]]
+name = "anyhow"
+version = "1.0.102"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "assert_cmd"
@@ -105,6 +111,21 @@ name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+
+[[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitflags"
@@ -232,7 +253,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -245,7 +266,16 @@ dependencies = [
  "libc",
  "once_cell",
  "unicode-width",
- "windows-sys 0.61.2",
+ "windows-sys",
+]
+
+[[package]]
+name = "convert_case"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baaaa0ecca5b51987b9423ccdc971514dd8b0bb7b4060b983d3664dad3f1f89f"
+dependencies = [
+ "unicode-segmentation",
 ]
 
 [[package]]
@@ -339,7 +369,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -364,6 +394,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
 name = "getrandom"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -372,6 +408,31 @@ dependencies = [
  "cfg-if",
  "libc",
  "wasi",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 5.3.0",
+ "wasip2",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 6.0.0",
+ "wasip2",
+ "wasip3",
 ]
 
 [[package]]
@@ -400,6 +461,15 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
@@ -409,6 +479,12 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
 name = "ignore"
@@ -435,7 +511,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.16.1",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -490,6 +568,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
 name = "libc"
 version = "0.2.182"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -507,9 +591,9 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.15"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "log"
@@ -570,9 +654,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.16.0"
+version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86f0b0d4bf799edbc74508c1e8bf170ff5f41238e5f8225603ca7caaae2b7860"
+checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "once_cell_polyfill"
@@ -585,6 +669,15 @@ name = "portable-atomic"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
 
 [[package]]
 name = "predicates"
@@ -617,6 +710,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -629,11 +732,40 @@ dependencies = [
 name = "project_configuration"
 version = "0.1.0"
 dependencies = [
+ "convert_case",
+ "nom",
+ "proptest",
  "serde",
  "serde_yaml",
+ "tempfile",
  "token_search",
  "totems",
 ]
+
+[[package]]
+name = "proptest"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37566cb3fdacef14c0737f9546df7cfeadbfbc9fef10991038bf5015d0c80532"
+dependencies = [
+ "bit-set",
+ "bit-vec",
+ "bitflags 2.11.0",
+ "num-traits",
+ "rand",
+ "rand_chacha",
+ "rand_xorshift",
+ "regex-syntax 0.8.10",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
+]
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quote"
@@ -642,6 +774,56 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rand"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+dependencies = [
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
+dependencies = [
+ "rand_core",
 ]
 
 [[package]]
@@ -689,7 +871,7 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.8",
  "redox_syscall",
  "thiserror",
 ]
@@ -702,7 +884,7 @@ checksum = "e076559ef8e241f2ae3479e36f97bd5741c0330689e217ad51ce2c76808b868a"
 dependencies = [
  "aho-corasick 0.7.20",
  "memchr",
- "regex-syntax",
+ "regex-syntax 0.6.28",
 ]
 
 [[package]]
@@ -718,16 +900,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "456c603be3e8d448b072f410900c09faf164fbce2d480456f50eea6e25f9c848"
 
 [[package]]
-name = "rustix"
-version = "0.38.44"
+name = "regex-syntax"
+version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+
+[[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
  "bitflags 2.11.0",
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -735,6 +923,18 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "rusty-fork"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2"
+dependencies = [
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
+]
 
 [[package]]
 name = "ryu"
@@ -756,6 +956,12 @@ name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+
+[[package]]
+name = "semver"
+version = "1.0.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
 
 [[package]]
 name = "serde"
@@ -843,14 +1049,15 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.10.1"
+version = "3.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85b77fafb263dd9d05cbeac119526425676db3784113aa9295c88498cbf8bff1"
+checksum = "82a72c767771b47409d2345987fda8628641887d5466101319899796367354a0"
 dependencies = [
- "cfg-if",
  "fastrand",
+ "getrandom 0.4.2",
+ "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -916,6 +1123,7 @@ dependencies = [
  "read_ctags",
  "serde",
  "serde_json",
+ "tempfile",
 ]
 
 [[package]]
@@ -925,16 +1133,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ced1de49b4b4739691bea1784503e2bda0466b98ce2988307594058a8d57e16a"
 
 [[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84a22b9f218b40614adcb3f4ff08b703773ad44fa9423e4e0d346d5db86e4ebc"
 
 [[package]]
+name = "unicode-segmentation"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+
+[[package]]
 name = "unicode-width"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "unit-prefix"
@@ -996,6 +1222,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
+name = "wasip2"
+version = "1.0.2+wasi-0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
 name = "wasm-bindgen"
 version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1038,6 +1282,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75a326b8c223ee17883a4251907455a2431acc2791c98c26279376490c378c16"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags 2.11.0",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "semver",
 ]
 
 [[package]]
@@ -1089,24 +1367,6 @@ checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-sys"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
-dependencies = [
- "windows-targets",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.59.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
-dependencies = [
- "windows-targets",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
@@ -1115,68 +1375,112 @@ dependencies = [
 ]
 
 [[package]]
-name = "windows-targets"
-version = "0.52.6"
+name = "wit-bindgen"
+version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "wit-bindgen-rust-macro",
 ]
 
 [[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.52.6"
+name = "wit-bindgen-core"
+version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
 
 [[package]]
-name = "windows_aarch64_msvc"
-version = "0.52.6"
+name = "wit-bindgen-rust"
+version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "prettyplease",
+ "syn 2.0.117",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
 
 [[package]]
-name = "windows_i686_gnu"
-version = "0.52.6"
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
 
 [[package]]
-name = "windows_i686_gnullvm"
-version = "0.52.6"
+name = "wit-component"
+version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags 2.11.0",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
 
 [[package]]
-name = "windows_i686_msvc"
-version = "0.52.6"
+name = "wit-parser"
+version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
 
 [[package]]
-name = "windows_x86_64_gnu"
-version = "0.52.6"
+name = "zerocopy"
+version = "0.8.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+checksum = "a789c6e490b576db9f7e6b6d661bcc9799f7c0ac8352f56ea20193b2681532e5"
+dependencies = [
+ "zerocopy-derive",
+]
 
 [[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.52.6"
+name = "zerocopy-derive"
+version = "0.8.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+checksum = "f65c489a7071a749c849713807783f70672b28094011623e200cb86dcb835953"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "zmij"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,6 @@ path = "src/bin/unused.rs"
 members = ["crates/*"]
 
 [workspace.dependencies]
-convert_case = "0.8"
 indicatif = { version = "0.18", features = ["rayon"] }
 itertools = "0.14"
 nom = "8"
@@ -47,7 +46,6 @@ proptest = "1.9"
 rayon = "1.11"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-tempfile = "3.23"
 totems = "0.2"
 
 [profile.release]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,12 +39,15 @@ path = "src/bin/unused.rs"
 members = ["crates/*"]
 
 [workspace.dependencies]
+convert_case = "0.8"
 indicatif = { version = "0.18", features = ["rayon"] }
 itertools = "0.14"
 nom = "8"
+proptest = "1.9"
 rayon = "1.11"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+tempfile = "3.23"
 totems = "0.2"
 
 [profile.release]

--- a/crates/cli/src/cli_configuration.rs
+++ b/crates/cli/src/cli_configuration.rs
@@ -2,7 +2,7 @@ use super::analyzed_token::AnalyzedToken;
 use super::formatters;
 use super::project_configurations_loader::load_and_parse_config;
 use super::{Flags, Format};
-use project_configuration::{AliasRule, AliasTemplatePart, AssertionConflict, ProjectConfiguration};
+use project_configuration::{AssertionConflict, ProjectConfiguration, expand_alias_candidates};
 use std::collections::{HashMap, HashSet};
 use token_analysis::{
     AnalysisFilter, SortOrder, TokenUsage, TokenUsageResults, UsageLikelihoodStatus,
@@ -210,53 +210,37 @@ fn build_alias_search_terms(
         .collect()
 }
 
-fn expand_alias_candidates(input: &str, alias_rules: &[AliasRule]) -> HashSet<String> {
-    let mut candidates = HashSet::from([input.to_string()]);
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use project_configuration::ProjectConfigurations;
 
-    for alias_rule in alias_rules {
-        let Some(capture) = input
-            .strip_prefix(&alias_rule.from.prefix)
-            .and_then(|rest| rest.strip_suffix(&alias_rule.from.suffix))
-        else {
-            continue;
-        };
+    #[test]
+    fn build_alias_search_terms_includes_have_alias_for_has_predicate() {
+        let configuration = ProjectConfigurations::parse(
+            "
+- name: Rails
+  method_aliases:
+    - from: '*?'
+      to: be_{}
+    - from: 'has_*?'
+      to: have_{}
+",
+        )
+        .expect("valid project configuration")
+        .get("Rails")
+        .cloned()
+        .expect("rails config");
 
-        let generated = render_alias_template(capture, &alias_rule.to.parts);
-        if generated != input {
-            candidates.insert(generated);
-        }
+        let aliases = build_alias_search_terms(
+            &[Token::new("has_attribute?".to_string(), Default::default())],
+            &configuration,
+        );
+        let terms = aliases
+            .get("has_attribute?")
+            .expect("alias terms for has_attribute?");
+
+        assert!(terms.contains("have_attribute"));
+        assert!(terms.contains("be_has_attribute"));
     }
-
-    candidates
-}
-
-fn render_alias_template(capture: &str, parts: &[AliasTemplatePart]) -> String {
-    parts
-        .iter()
-        .map(|part| match part {
-            AliasTemplatePart::Literal(value) => value.to_string(),
-            AliasTemplatePart::Capture => capture.to_string(),
-            AliasTemplatePart::SnakecaseCapture => snakecase(capture),
-        })
-        .collect::<Vec<_>>()
-        .join("")
-}
-
-fn snakecase(value: &str) -> String {
-    let mut out = String::new();
-    let chars: Vec<char> = value.chars().collect();
-
-    for (i, ch) in chars.iter().enumerate() {
-        if i > 0 && ch.is_uppercase() {
-            let prev = chars[i - 1];
-            let next_is_lowercase = chars.get(i + 1).is_some_and(|next| next.is_lowercase());
-            if prev.is_lowercase() || (prev.is_uppercase() && next_is_lowercase) {
-                out.push('_');
-            }
-        }
-
-        out.extend(ch.to_lowercase());
-    }
-
-    out
 }

--- a/crates/cli/src/cli_configuration.rs
+++ b/crates/cli/src/cli_configuration.rs
@@ -18,23 +18,23 @@ pub struct CliConfiguration<'a> {
 }
 
 impl<'a> CliConfiguration<'a> {
-    pub fn new(flags: &'a Flags, tokens: Vec<Token>) -> Self {
+    pub fn new(flags: &'a Flags, tokens: Vec<Token>) -> Result<Self, String> {
         let token_search_config = build_token_search_config(flags, tokens);
         let analysis_filter = build_analysis_filter(flags);
         let results = TokenSearchResults::generate_with_config(&token_search_config);
-        let project_configuration = load_and_parse_config()
+        let project_configuration = load_and_parse_config()?
             .best_match(&results)
             .unwrap_or_default();
         let outcome =
             TokenUsageResults::calculate(&token_search_config, &results, &project_configuration);
 
-        Self {
+        Ok(Self {
             flags,
             token_search_config,
             analysis_filter,
             project_configuration,
             outcome,
-        }
+        })
     }
 
     pub fn render(&self) {

--- a/crates/cli/src/cli_configuration.rs
+++ b/crates/cli/src/cli_configuration.rs
@@ -2,7 +2,7 @@ use super::analyzed_token::AnalyzedToken;
 use super::formatters;
 use super::project_configurations_loader::load_and_parse_config;
 use super::{Flags, Format};
-use project_configuration::{AssertionConflict, ProjectConfiguration};
+use project_configuration::{AliasRule, AliasTemplatePart, AssertionConflict, ProjectConfiguration};
 use std::collections::{HashMap, HashSet};
 use token_analysis::{
     AnalysisFilter, SortOrder, TokenUsage, TokenUsageResults, UsageLikelihoodStatus,
@@ -19,12 +19,15 @@ pub struct CliConfiguration<'a> {
 
 impl<'a> CliConfiguration<'a> {
     pub fn new(flags: &'a Flags, tokens: Vec<Token>) -> Result<Self, String> {
-        let token_search_config = build_token_search_config(flags, tokens);
+        let mut token_search_config = build_token_search_config(flags, tokens);
         let analysis_filter = build_analysis_filter(flags);
-        let results = TokenSearchResults::generate_with_config(&token_search_config);
+        let initial_results = TokenSearchResults::generate_with_config(&token_search_config);
         let project_configuration = load_and_parse_config()?
-            .best_match(&results)
+            .best_match(&initial_results)
             .unwrap_or_default();
+        token_search_config.token_aliases =
+            build_alias_search_terms(&token_search_config.tokens, &project_configuration);
+        let results = TokenSearchResults::generate_with_config(&token_search_config);
         let outcome =
             TokenUsageResults::calculate(&token_search_config, &results, &project_configuration);
 
@@ -178,4 +181,82 @@ where
     T: std::hash::Hash + Eq + std::clone::Clone,
 {
     input.iter().cloned().collect::<HashSet<_>>()
+}
+
+fn build_alias_search_terms(
+    tokens: &[Token],
+    project_configuration: &ProjectConfiguration,
+) -> HashMap<String, HashSet<String>> {
+    if project_configuration.method_aliases.is_empty() {
+        return HashMap::new();
+    }
+
+    tokens
+        .iter()
+        .filter_map(|token| {
+            let generated_terms =
+                expand_alias_candidates(&token.token, &project_configuration.method_aliases);
+            let alias_terms = generated_terms
+                .into_iter()
+                .filter(|candidate| candidate != &token.token)
+                .collect::<HashSet<_>>();
+
+            if alias_terms.is_empty() {
+                None
+            } else {
+                Some((token.token.clone(), alias_terms))
+            }
+        })
+        .collect()
+}
+
+fn expand_alias_candidates(input: &str, alias_rules: &[AliasRule]) -> HashSet<String> {
+    let mut candidates = HashSet::from([input.to_string()]);
+
+    for alias_rule in alias_rules {
+        let Some(capture) = input
+            .strip_prefix(&alias_rule.from.prefix)
+            .and_then(|rest| rest.strip_suffix(&alias_rule.from.suffix))
+        else {
+            continue;
+        };
+
+        let generated = render_alias_template(capture, &alias_rule.to.parts);
+        if generated != input {
+            candidates.insert(generated);
+        }
+    }
+
+    candidates
+}
+
+fn render_alias_template(capture: &str, parts: &[AliasTemplatePart]) -> String {
+    parts
+        .iter()
+        .map(|part| match part {
+            AliasTemplatePart::Literal(value) => value.to_string(),
+            AliasTemplatePart::Capture => capture.to_string(),
+            AliasTemplatePart::SnakecaseCapture => snakecase(capture),
+        })
+        .collect::<Vec<_>>()
+        .join("")
+}
+
+fn snakecase(value: &str) -> String {
+    let mut out = String::new();
+    let chars: Vec<char> = value.chars().collect();
+
+    for (i, ch) in chars.iter().enumerate() {
+        if i > 0 && ch.is_uppercase() {
+            let prev = chars[i - 1];
+            let next_is_lowercase = chars.get(i + 1).is_some_and(|next| next.is_lowercase());
+            if prev.is_lowercase() || (prev.is_uppercase() && next_is_lowercase) {
+                out.push('_');
+            }
+        }
+
+        out.extend(ch.to_lowercase());
+    }
+
+    out
 }

--- a/crates/cli/src/doctor/loaded_project_configurations.rs
+++ b/crates/cli/src/doctor/loaded_project_configurations.rs
@@ -4,7 +4,7 @@ use super::{
 };
 use project_configuration::ProjectConfigurations;
 
-pub struct LoadedProjectConfigurations(ProjectConfigurations);
+pub struct LoadedProjectConfigurations(Result<ProjectConfigurations, String>);
 
 impl LoadedProjectConfigurations {
     pub fn new() -> Self {
@@ -12,7 +12,10 @@ impl LoadedProjectConfigurations {
     }
 
     fn config_keys(&self) -> Vec<String> {
-        self.0.project_config_names()
+        match &self.0 {
+            Ok(configurations) => configurations.project_config_names(),
+            Err(_) => vec![],
+        }
     }
 }
 
@@ -22,15 +25,21 @@ impl CheckUp for LoadedProjectConfigurations {
     }
 
     fn status(&self) -> Status {
-        if self.config_keys().is_empty() {
-            Status::Warn(
-                "No project configurations were loaded; using default config instead.".to_string(),
-            )
-        } else {
-            Status::OK(format!(
-                "Loaded the following project configurations: {}",
-                self.config_keys().join(", ")
-            ))
+        match &self.0 {
+            Ok(_) => {
+                if self.config_keys().is_empty() {
+                    Status::Warn(
+                        "No project configurations were loaded; using default config instead."
+                            .to_string(),
+                    )
+                } else {
+                    Status::OK(format!(
+                        "Loaded the following project configurations: {}",
+                        self.config_keys().join(", ")
+                    ))
+                }
+            }
+            Err(error) => Status::Error(error.clone()),
         }
     }
 }

--- a/crates/cli/src/error_message.rs
+++ b/crates/cli/src/error_message.rs
@@ -17,3 +17,9 @@ pub fn failed_token_parse(err: &ReadCtagsError) {
     eprintln!("Error:");
     eprintln!("{}", err.to_string().cyan());
 }
+
+pub fn failed_project_config_parse(err: &str) {
+    eprintln!("{}", "Failed to load project configuration".red());
+    eprintln!();
+    eprintln!("{err}");
+}

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -40,20 +40,18 @@ pub fn run() {
         Some(flags::Command::Doctor) => Doctor::new(&tags_reader).render(),
         Some(flags::Command::DefaultYaml) => println!("{}", ProjectConfigurations::default_yaml()),
         None => match Token::all(&tags_reader) {
-            Ok((_, results)) => {
-                match CliConfiguration::new(&flags, results) {
-                    Ok(configuration) => {
-                        configuration.render();
-                        if flags.harsh && !configuration.analyses().is_empty() {
-                            process::exit(1);
-                        }
-                    }
-                    Err(error) => {
-                        error_message::failed_project_config_parse(&error);
+            Ok((_, results)) => match CliConfiguration::new(&flags, results) {
+                Ok(configuration) => {
+                    configuration.render();
+                    if flags.harsh && !configuration.analyses().is_empty() {
                         process::exit(1);
                     }
                 }
-            }
+                Err(error) => {
+                    error_message::failed_project_config_parse(&error);
+                    process::exit(1);
+                }
+            },
             Err(e) => {
                 error_message::failed_token_parse(&e);
                 process::exit(1)

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -41,10 +41,17 @@ pub fn run() {
         Some(flags::Command::DefaultYaml) => println!("{}", ProjectConfigurations::default_yaml()),
         None => match Token::all(&tags_reader) {
             Ok((_, results)) => {
-                let configuration = CliConfiguration::new(&flags, results);
-                configuration.render();
-                if flags.harsh && !configuration.analyses().is_empty() {
-                    process::exit(1);
+                match CliConfiguration::new(&flags, results) {
+                    Ok(configuration) => {
+                        configuration.render();
+                        if flags.harsh && !configuration.analyses().is_empty() {
+                            process::exit(1);
+                        }
+                    }
+                    Err(error) => {
+                        error_message::failed_project_config_parse(&error);
+                        process::exit(1);
+                    }
                 }
             }
             Err(e) => {

--- a/crates/cli/src/project_configurations_loader.rs
+++ b/crates/cli/src/project_configurations_loader.rs
@@ -17,15 +17,11 @@ fn load_from_user_config_path(path: &str) -> Result<ProjectConfigurations, Strin
             .map_err(|error| format!("Failed to parse bundled default config: {error}"));
     }
 
-    let contents = read_file(path).map_err(|error| {
-        format!("Failed to read project configuration from `{path}`: {error}")
-    })?;
+    let contents = read_file(path)
+        .map_err(|error| format!("Failed to read project configuration from `{path}`: {error}"))?;
 
-    ProjectConfigurations::parse(&contents).map_err(|error| {
-        format!(
-            "Failed to parse project configuration from `{path}`: {error}"
-        )
-    })
+    ProjectConfigurations::parse(&contents)
+        .map_err(|error| format!("Failed to parse project configuration from `{path}`: {error}"))
 }
 
 fn file_path_in_home_dir(file_name: &str) -> Option<String> {

--- a/crates/cli/src/project_configurations_loader.rs
+++ b/crates/cli/src/project_configurations_loader.rs
@@ -3,11 +3,29 @@ use std::fs;
 use std::io;
 use std::path::Path;
 
-pub fn load_and_parse_config() -> ProjectConfigurations {
-    let contents = file_path_in_home_dir(".config/unused/unused.yml")
-        .and_then(|path| read_file(&path).ok())
-        .unwrap_or(ProjectConfigurations::default_yaml());
-    ProjectConfigurations::parse(&contents)
+pub fn load_and_parse_config() -> Result<ProjectConfigurations, String> {
+    match file_path_in_home_dir(".config/unused/unused.yml") {
+        Some(path) => load_from_user_config_path(&path),
+        None => ProjectConfigurations::parse(ProjectConfigurations::default_yaml().as_str())
+            .map_err(|error| format!("Failed to parse bundled default config: {error}")),
+    }
+}
+
+fn load_from_user_config_path(path: &str) -> Result<ProjectConfigurations, String> {
+    if !Path::new(path).exists() {
+        return ProjectConfigurations::parse(ProjectConfigurations::default_yaml().as_str())
+            .map_err(|error| format!("Failed to parse bundled default config: {error}"));
+    }
+
+    let contents = read_file(path).map_err(|error| {
+        format!("Failed to read project configuration from `{path}`: {error}")
+    })?;
+
+    ProjectConfigurations::parse(&contents).map_err(|error| {
+        format!(
+            "Failed to parse project configuration from `{path}`: {error}"
+        )
+    })
 }
 
 fn file_path_in_home_dir(file_name: &str) -> Option<String> {

--- a/crates/project_configuration/Cargo.toml
+++ b/crates/project_configuration/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-convert_case = { workspace = true }
+convert_case = "0.11"
 nom = { workspace = true }
 serde = { workspace = true }
 serde_yaml = "0.9"
@@ -16,5 +16,4 @@ token_search = { path = "../../crates/token_search" }
 
 [dev-dependencies]
 proptest = { workspace = true }
-tempfile = { workspace = true }
 totems = { workspace = true }

--- a/crates/project_configuration/Cargo.toml
+++ b/crates/project_configuration/Cargo.toml
@@ -8,9 +8,13 @@ license = "MIT"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+convert_case = { workspace = true }
+nom = { workspace = true }
 serde = { workspace = true }
 serde_yaml = "0.9"
 token_search = { path = "../../crates/token_search" }
 
 [dev-dependencies]
+proptest = { workspace = true }
+tempfile = { workspace = true }
 totems = { workspace = true }

--- a/crates/project_configuration/src/alias_rules.rs
+++ b/crates/project_configuration/src/alias_rules.rs
@@ -12,49 +12,56 @@ use serde::Deserialize;
 use std::collections::HashSet;
 
 #[derive(Clone, Debug, Deserialize, PartialEq)]
-pub struct RawAliasRule {
-    pub from: String,
-    pub to: String,
+pub(super) struct RawAliasRule {
+    from: String,
+    to: String,
 }
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct AliasRule {
-    pub from: AliasFromPattern,
-    pub to: AliasTemplate,
+    from: AliasFromPattern,
+    to: AliasTemplate,
+}
+
+impl AliasRule {
+    #[allow(dead_code)]
+    pub(crate) fn new(from: AliasFromPattern, to: AliasTemplate) -> Self {
+        Self { from, to }
+    }
 }
 
 #[derive(Clone, Debug, PartialEq)]
-pub struct AliasFromPattern {
+pub(crate) struct AliasFromPattern {
     pub raw: String,
     pub prefix: String,
     pub suffix: String,
 }
 
 #[derive(Clone, Debug, PartialEq)]
-pub struct AliasTemplate {
+pub(crate) struct AliasTemplate {
     pub raw: String,
     pub parts: Vec<AliasTemplatePart>,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub enum AliasTransform {
+pub(crate) enum AliasTransform {
     Snakecase,
 }
 
 #[derive(Clone, Debug, PartialEq)]
-pub enum AliasTemplatePart {
+pub(crate) enum AliasTemplatePart {
     Literal(String),
     Capture(Vec<AliasTransform>),
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub enum AliasRuleField {
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum AliasRuleField {
     From,
     To,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub struct AliasRuleValidationError {
+pub(super) struct AliasRuleValidationError {
     pub rule_index: usize,
     pub field: AliasRuleField,
     pub message: String,
@@ -345,7 +352,7 @@ mod tests {
                 AliasRule {
                     from: AliasFromPattern {
                         raw: "*?".to_string(),
-                        prefix: "".to_string(),
+                        prefix: String::new(),
                         suffix: "?".to_string(),
                     },
                     to: AliasTemplate {
@@ -394,7 +401,7 @@ mod tests {
             Ok(vec![AliasRule {
                 from: AliasFromPattern {
                     raw: "*Validator".to_string(),
-                    prefix: "".to_string(),
+                    prefix: String::new(),
                     suffix: "Validator".to_string(),
                 },
                 to: AliasTemplate {

--- a/crates/project_configuration/src/alias_rules.rs
+++ b/crates/project_configuration/src/alias_rules.rs
@@ -137,7 +137,9 @@ fn parse_template(
             Some(offset) => {
                 let open = cursor + offset;
                 if open > cursor {
-                    parts.push(AliasTemplatePart::Literal(raw_template[cursor..open].to_string()));
+                    parts.push(AliasTemplatePart::Literal(
+                        raw_template[cursor..open].to_string(),
+                    ));
                 }
 
                 let token_start = open + 1;
@@ -149,7 +151,7 @@ fn parse_template(
                         return Err(AliasRuleValidationError::to_error(
                             rule_index,
                             "to template has an unclosed `{` token".to_string(),
-                        ))
+                        ));
                     }
                 };
 
@@ -161,14 +163,16 @@ fn parse_template(
                         return Err(AliasRuleValidationError::to_error(
                             rule_index,
                             format!("unsupported to template token `{{{token}}}`"),
-                        ))
+                        ));
                     }
                 }
 
                 cursor = close + 1;
             }
             None => {
-                parts.push(AliasTemplatePart::Literal(raw_template[cursor..].to_string()));
+                parts.push(AliasTemplatePart::Literal(
+                    raw_template[cursor..].to_string(),
+                ));
                 cursor = raw_template.len();
             }
         }
@@ -189,6 +193,27 @@ mod tests {
             from: from.to_string(),
             to: to.to_string(),
         }
+    }
+
+    fn assert_error(
+        errors: &[AliasRuleValidationError],
+        rule_index: usize,
+        field: AliasRuleField,
+        message_fragment: &str,
+    ) {
+        let matching_error = errors
+            .iter()
+            .find(|error| error.rule_index == rule_index && error.field == field)
+            .unwrap_or_else(|| {
+                panic!("missing error for rule {rule_index}, field {field:?}: {errors:?}")
+            });
+
+        assert!(
+            matching_error.message.contains(message_fragment),
+            "expected `{}` to contain `{}`",
+            matching_error.message,
+            message_fragment,
+        );
     }
 
     #[test]
@@ -249,13 +274,11 @@ mod tests {
     fn compile_alias_rules_rejects_from_without_wildcard() {
         let result = compile_alias_rules(&[raw_rule("admin?", "be_{}")]).unwrap_err();
 
-        assert_eq!(
-            result,
-            vec![AliasRuleValidationError {
-                rule_index: 0,
-                field: AliasRuleField::From,
-                message: "from pattern must contain exactly one `*` wildcard".to_string(),
-            }]
+        assert_error(
+            &result,
+            0,
+            AliasRuleField::From,
+            "exactly one `*` wildcard",
         );
     }
 
@@ -263,13 +286,11 @@ mod tests {
     fn compile_alias_rules_rejects_from_with_multiple_wildcards() {
         let result = compile_alias_rules(&[raw_rule("*foo*", "be_{}")]).unwrap_err();
 
-        assert_eq!(
-            result,
-            vec![AliasRuleValidationError {
-                rule_index: 0,
-                field: AliasRuleField::From,
-                message: "from pattern must contain exactly one `*` wildcard".to_string(),
-            }]
+        assert_error(
+            &result,
+            0,
+            AliasRuleField::From,
+            "exactly one `*` wildcard",
         );
     }
 
@@ -277,13 +298,11 @@ mod tests {
     fn compile_alias_rules_rejects_unknown_to_token() {
         let result = compile_alias_rules(&[raw_rule("*?", "be_{camelcase}")]).unwrap_err();
 
-        assert_eq!(
-            result,
-            vec![AliasRuleValidationError {
-                rule_index: 0,
-                field: AliasRuleField::To,
-                message: "unsupported to template token `{camelcase}`".to_string(),
-            }]
+        assert_error(
+            &result,
+            0,
+            AliasRuleField::To,
+            "unsupported to template token",
         );
     }
 
@@ -291,13 +310,19 @@ mod tests {
     fn compile_alias_rules_rejects_unclosed_to_token() {
         let result = compile_alias_rules(&[raw_rule("*?", "be_{")]).unwrap_err();
 
-        assert_eq!(
-            result,
-            vec![AliasRuleValidationError {
-                rule_index: 0,
-                field: AliasRuleField::To,
-                message: "to template has an unclosed `{` token".to_string(),
-            }]
-        );
+        assert_error(&result, 0, AliasRuleField::To, "unclosed `{` token");
+    }
+
+    #[test]
+    fn compile_alias_rules_reports_multiple_validation_classes_order_independently() {
+        let result = compile_alias_rules(&[
+            raw_rule("admin?", "be_{}"),
+            raw_rule("*?", "be_{camelcase}"),
+        ])
+        .unwrap_err();
+
+        assert_eq!(result.len(), 2);
+        assert_error(&result, 0, AliasRuleField::From, "exactly one `*` wildcard");
+        assert_error(&result, 1, AliasRuleField::To, "unsupported to template token");
     }
 }

--- a/crates/project_configuration/src/alias_rules.rs
+++ b/crates/project_configuration/src/alias_rules.rs
@@ -1,4 +1,15 @@
+use convert_case::{Case, Casing};
+use nom::{
+    IResult, Parser,
+    branch::alt,
+    bytes::complete::{tag, take_till, take_till1},
+    character::complete::{char, space0},
+    combinator::{all_consuming, recognize, value},
+    multi::{many0, separated_list1},
+    sequence::{delimited, pair, separated_pair},
+};
 use serde::Deserialize;
+use std::collections::HashSet;
 
 #[derive(Clone, Debug, Deserialize, PartialEq)]
 pub struct RawAliasRule {
@@ -25,11 +36,15 @@ pub struct AliasTemplate {
     pub parts: Vec<AliasTemplatePart>,
 }
 
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum AliasTransform {
+    Snakecase,
+}
+
 #[derive(Clone, Debug, PartialEq)]
 pub enum AliasTemplatePart {
     Literal(String),
-    Capture,
-    SnakecaseCapture,
+    Capture(Vec<AliasTransform>),
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -63,6 +78,11 @@ impl AliasRuleValidationError {
     }
 }
 
+/// Compile raw alias rules into parsed matching/rendering components.
+///
+/// # Errors
+///
+/// Returns all rule validation errors when one or more `from`/`to` patterns are invalid.
 pub fn compile_alias_rules(
     raw_rules: &[RawAliasRule],
 ) -> Result<Vec<AliasRule>, Vec<AliasRuleValidationError>> {
@@ -96,31 +116,89 @@ pub fn compile_alias_rules(
     }
 }
 
+#[must_use]
+pub fn expand_alias_candidates(input: &str, alias_rules: &[AliasRule]) -> HashSet<String> {
+    let mut candidates = HashSet::from([input.to_string()]);
+
+    for alias_rule in alias_rules {
+        let Some(capture) = input
+            .strip_prefix(&alias_rule.from.prefix)
+            .and_then(|rest| rest.strip_suffix(&alias_rule.from.suffix))
+        else {
+            continue;
+        };
+
+        let generated = render_alias_template(capture, &alias_rule.to.parts);
+        if generated != input {
+            candidates.insert(generated);
+        }
+    }
+
+    candidates
+}
+
+#[must_use]
+pub fn render_alias_template(capture: &str, parts: &[AliasTemplatePart]) -> String {
+    let mut rendered = String::new();
+
+    for part in parts {
+        match part {
+            AliasTemplatePart::Literal(value) => rendered.push_str(value),
+            AliasTemplatePart::Capture(transforms) => {
+                rendered.push_str(&apply_alias_transforms(capture, transforms));
+            }
+        }
+    }
+
+    rendered
+}
+
+#[must_use]
+pub fn apply_alias_transforms(value: &str, transforms: &[AliasTransform]) -> String {
+    transforms
+        .iter()
+        .fold(value.to_string(), |acc, transform| transform.apply(&acc))
+}
+
+impl AliasTransform {
+    fn apply(&self, value: &str) -> String {
+        match self {
+            AliasTransform::Snakecase => value.to_case(Case::Snake),
+        }
+    }
+}
+
 fn parse_from_pattern(
     rule_index: usize,
     raw_pattern: &str,
 ) -> Result<AliasFromPattern, AliasRuleValidationError> {
-    let wildcard_indices = raw_pattern
-        .char_indices()
-        .filter_map(|(idx, ch)| (ch == '*').then_some(idx))
-        .collect::<Vec<usize>>();
+    let (_, (prefix, suffix)) = alias_from_pattern(raw_pattern).map_err(|_| {
+        AliasRuleValidationError::from_error(
+            rule_index,
+            "from pattern must contain exactly one `*` wildcard".to_string(),
+        )
+    })?;
 
-    if wildcard_indices.len() != 1 {
+    if suffix.contains('*') {
         return Err(AliasRuleValidationError::from_error(
             rule_index,
             "from pattern must contain exactly one `*` wildcard".to_string(),
         ));
     }
 
-    let wildcard_index = wildcard_indices[0];
-    let prefix = raw_pattern[..wildcard_index].to_string();
-    let suffix = raw_pattern[(wildcard_index + 1)..].to_string();
-
     Ok(AliasFromPattern {
         raw: raw_pattern.to_string(),
-        prefix,
-        suffix,
+        prefix: prefix.to_string(),
+        suffix: suffix.to_string(),
     })
+}
+
+fn alias_from_pattern(input: &str) -> IResult<&str, (&str, &str)> {
+    separated_pair(take_till(|ch| ch == '*'), char('*'), take_till(|_| false)).parse(input)
+}
+
+fn literal_chunk(input: &str) -> IResult<&str, &str> {
+    take_till1(|ch| ch == '{').parse(input)
 }
 
 fn parse_template(
@@ -128,54 +206,28 @@ fn parse_template(
     raw_template: &str,
 ) -> Result<AliasTemplate, AliasRuleValidationError> {
     let mut parts = Vec::new();
-    let mut cursor = 0;
+    let mut remaining = raw_template;
 
-    while cursor < raw_template.len() {
-        let open_offset = raw_template[cursor..].find('{');
+    while !remaining.is_empty() {
+        if remaining.starts_with('{') {
+            let (rest, capture_token) = capture_token_raw(remaining).map_err(|_| {
+                AliasRuleValidationError::to_error(
+                    rule_index,
+                    "to template has an unclosed `{` token".to_string(),
+                )
+            })?;
 
-        match open_offset {
-            Some(offset) => {
-                let open = cursor + offset;
-                if open > cursor {
-                    parts.push(AliasTemplatePart::Literal(
-                        raw_template[cursor..open].to_string(),
-                    ));
-                }
-
-                let token_start = open + 1;
-                let close_offset = raw_template[token_start..].find('}');
-
-                let close = match close_offset {
-                    Some(offset) => token_start + offset,
-                    None => {
-                        return Err(AliasRuleValidationError::to_error(
-                            rule_index,
-                            "to template has an unclosed `{` token".to_string(),
-                        ));
-                    }
-                };
-
-                let token = &raw_template[token_start..close];
-                match token {
-                    "" => parts.push(AliasTemplatePart::Capture),
-                    "snakecase" => parts.push(AliasTemplatePart::SnakecaseCapture),
-                    _ => {
-                        return Err(AliasRuleValidationError::to_error(
-                            rule_index,
-                            format!("unsupported to template token `{{{token}}}`"),
-                        ));
-                    }
-                }
-
-                cursor = close + 1;
-            }
-            None => {
-                parts.push(AliasTemplatePart::Literal(
-                    raw_template[cursor..].to_string(),
-                ));
-                cursor = raw_template.len();
-            }
+            let transforms = parse_capture_transforms(rule_index, capture_token)?;
+            parts.push(AliasTemplatePart::Capture(transforms));
+            remaining = rest;
+            continue;
         }
+
+        let (rest, literal) = literal_chunk(remaining).map_err(|_| {
+            AliasRuleValidationError::to_error(rule_index, "invalid to template".to_string())
+        })?;
+        parts.push(AliasTemplatePart::Literal(literal.to_string()));
+        remaining = rest;
     }
 
     Ok(AliasTemplate {
@@ -184,9 +236,72 @@ fn parse_template(
     })
 }
 
+fn capture_token_raw(input: &str) -> IResult<&str, &str> {
+    delimited(char('{'), take_till(|ch| ch == '}'), char('}')).parse(input)
+}
+
+fn parse_capture_transforms(
+    rule_index: usize,
+    capture_token: &str,
+) -> Result<Vec<AliasTransform>, AliasRuleValidationError> {
+    if capture_token.trim().is_empty() {
+        return Ok(vec![]);
+    }
+
+    let (_, transform_names) = capture_transform_names(capture_token).map_err(|_| {
+        AliasRuleValidationError::to_error(
+            rule_index,
+            format!(
+                "unsupported to template token `{{{capture_token}}}`; expected pipe-delimited transforms"
+            ),
+        )
+    })?;
+
+    transform_names
+        .into_iter()
+        .map(|name| parse_transform(rule_index, name))
+        .collect()
+}
+
+fn capture_transform_names(input: &str) -> IResult<&str, Vec<&str>> {
+    all_consuming(separated_list1(
+        delimited(space0, char('|'), space0),
+        transform_name,
+    ))
+    .parse(input)
+}
+
+fn transform_name(input: &str) -> IResult<&str, &str> {
+    recognize(pair(
+        alt((tag("_"), nom::character::complete::alpha1)),
+        many0(alt((tag("_"), nom::character::complete::alphanumeric1))),
+    ))
+    .parse(input)
+}
+
+fn parse_transform(
+    rule_index: usize,
+    name: &str,
+) -> Result<AliasTransform, AliasRuleValidationError> {
+    all_consuming(known_transform)
+        .parse(name)
+        .map(|(_, transform)| transform)
+        .map_err(|_| {
+            AliasRuleValidationError::to_error(
+                rule_index,
+                format!("unsupported to template transform `{name}`"),
+            )
+        })
+}
+
+fn known_transform(input: &str) -> IResult<&str, AliasTransform> {
+    value(AliasTransform::Snakecase, tag("snakecase")).parse(input)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use proptest::prelude::*;
 
     fn raw_rule(from: &str, to: &str) -> RawAliasRule {
         RawAliasRule {
@@ -237,7 +352,7 @@ mod tests {
                         raw: "be_{}".to_string(),
                         parts: vec![
                             AliasTemplatePart::Literal("be_".to_string()),
-                            AliasTemplatePart::Capture,
+                            AliasTemplatePart::Capture(vec![]),
                         ],
                     },
                 },
@@ -251,7 +366,7 @@ mod tests {
                         raw: "have_{}".to_string(),
                         parts: vec![
                             AliasTemplatePart::Literal("have_".to_string()),
-                            AliasTemplatePart::Capture,
+                            AliasTemplatePart::Capture(vec![]),
                         ],
                     },
                 },
@@ -263,7 +378,7 @@ mod tests {
                     },
                     to: AliasTemplate {
                         raw: "{snakecase}".to_string(),
-                        parts: vec![AliasTemplatePart::SnakecaseCapture],
+                        parts: vec![AliasTemplatePart::Capture(vec![AliasTransform::Snakecase])],
                     },
                 },
             ])
@@ -271,32 +386,57 @@ mod tests {
     }
 
     #[test]
+    fn compile_alias_rules_accepts_pipe_delimited_transform_syntax() {
+        let result = compile_alias_rules(&[raw_rule("*Validator", "{snakecase | snakecase}")]);
+
+        assert_eq!(
+            result,
+            Ok(vec![AliasRule {
+                from: AliasFromPattern {
+                    raw: "*Validator".to_string(),
+                    prefix: "".to_string(),
+                    suffix: "Validator".to_string(),
+                },
+                to: AliasTemplate {
+                    raw: "{snakecase | snakecase}".to_string(),
+                    parts: vec![AliasTemplatePart::Capture(vec![
+                        AliasTransform::Snakecase,
+                        AliasTransform::Snakecase,
+                    ])],
+                },
+            }])
+        );
+    }
+
+    #[test]
     fn compile_alias_rules_rejects_from_without_wildcard() {
         let result = compile_alias_rules(&[raw_rule("admin?", "be_{}")]).unwrap_err();
 
-        assert_error(
-            &result,
-            0,
-            AliasRuleField::From,
-            "exactly one `*` wildcard",
-        );
+        assert_error(&result, 0, AliasRuleField::From, "exactly one `*` wildcard");
     }
 
     #[test]
     fn compile_alias_rules_rejects_from_with_multiple_wildcards() {
         let result = compile_alias_rules(&[raw_rule("*foo*", "be_{}")]).unwrap_err();
 
+        assert_error(&result, 0, AliasRuleField::From, "exactly one `*` wildcard");
+    }
+
+    #[test]
+    fn compile_alias_rules_rejects_unknown_to_transform() {
+        let result = compile_alias_rules(&[raw_rule("*?", "be_{camelcase}")]).unwrap_err();
+
         assert_error(
             &result,
             0,
-            AliasRuleField::From,
-            "exactly one `*` wildcard",
+            AliasRuleField::To,
+            "unsupported to template transform",
         );
     }
 
     #[test]
-    fn compile_alias_rules_rejects_unknown_to_token() {
-        let result = compile_alias_rules(&[raw_rule("*?", "be_{camelcase}")]).unwrap_err();
+    fn compile_alias_rules_rejects_bad_transform_pipeline() {
+        let result = compile_alias_rules(&[raw_rule("*?", "be_{snakecase | }")]).unwrap_err();
 
         assert_error(
             &result,
@@ -323,6 +463,34 @@ mod tests {
 
         assert_eq!(result.len(), 2);
         assert_error(&result, 0, AliasRuleField::From, "exactly one `*` wildcard");
-        assert_error(&result, 1, AliasRuleField::To, "unsupported to template token");
+        assert_error(
+            &result,
+            1,
+            AliasRuleField::To,
+            "unsupported to template transform",
+        );
+    }
+
+    proptest! {
+        #[test]
+        fn expands_wildcard_alias_for_question_methods(stem in "[A-Za-z_][A-Za-z0-9_]{0,20}") {
+            let rules = compile_alias_rules(&[raw_rule("*?", "be_{}")]).expect("compile rules");
+            let input = format!("{stem}?");
+            let candidates = expand_alias_candidates(&input, &rules);
+            let expected_alias = format!("be_{stem}");
+
+            prop_assert!(candidates.contains(&input));
+            prop_assert!(candidates.contains(&expected_alias));
+        }
+
+        #[test]
+        fn snakecase_transform_is_deterministic(class_name in "[A-Z][A-Za-z0-9]{0,20}Validator") {
+            let rules = compile_alias_rules(&[raw_rule("*Validator", "{snakecase}")]).expect("compile rules");
+
+            let first = expand_alias_candidates(&class_name, &rules);
+            let second = expand_alias_candidates(&class_name, &rules);
+
+            prop_assert_eq!(first, second);
+        }
     }
 }

--- a/crates/project_configuration/src/alias_rules.rs
+++ b/crates/project_configuration/src/alias_rules.rs
@@ -1,0 +1,303 @@
+use serde::Deserialize;
+
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+pub struct RawAliasRule {
+    pub from: String,
+    pub to: String,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct AliasRule {
+    pub from: AliasFromPattern,
+    pub to: AliasTemplate,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct AliasFromPattern {
+    pub raw: String,
+    pub prefix: String,
+    pub suffix: String,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct AliasTemplate {
+    pub raw: String,
+    pub parts: Vec<AliasTemplatePart>,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum AliasTemplatePart {
+    Literal(String),
+    Capture,
+    SnakecaseCapture,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum AliasRuleField {
+    From,
+    To,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct AliasRuleValidationError {
+    pub rule_index: usize,
+    pub field: AliasRuleField,
+    pub message: String,
+}
+
+impl AliasRuleValidationError {
+    fn from_error(rule_index: usize, message: String) -> Self {
+        Self {
+            rule_index,
+            field: AliasRuleField::From,
+            message,
+        }
+    }
+
+    fn to_error(rule_index: usize, message: String) -> Self {
+        Self {
+            rule_index,
+            field: AliasRuleField::To,
+            message,
+        }
+    }
+}
+
+pub fn compile_alias_rules(
+    raw_rules: &[RawAliasRule],
+) -> Result<Vec<AliasRule>, Vec<AliasRuleValidationError>> {
+    let mut compiled_rules = Vec::new();
+    let mut errors = Vec::new();
+
+    for (rule_index, raw_rule) in raw_rules.iter().enumerate() {
+        let from = match parse_from_pattern(rule_index, &raw_rule.from) {
+            Ok(from) => from,
+            Err(error) => {
+                errors.push(error);
+                continue;
+            }
+        };
+
+        let to = match parse_template(rule_index, &raw_rule.to) {
+            Ok(to) => to,
+            Err(error) => {
+                errors.push(error);
+                continue;
+            }
+        };
+
+        compiled_rules.push(AliasRule { from, to });
+    }
+
+    if errors.is_empty() {
+        Ok(compiled_rules)
+    } else {
+        Err(errors)
+    }
+}
+
+fn parse_from_pattern(
+    rule_index: usize,
+    raw_pattern: &str,
+) -> Result<AliasFromPattern, AliasRuleValidationError> {
+    let wildcard_indices = raw_pattern
+        .char_indices()
+        .filter_map(|(idx, ch)| (ch == '*').then_some(idx))
+        .collect::<Vec<usize>>();
+
+    if wildcard_indices.len() != 1 {
+        return Err(AliasRuleValidationError::from_error(
+            rule_index,
+            "from pattern must contain exactly one `*` wildcard".to_string(),
+        ));
+    }
+
+    let wildcard_index = wildcard_indices[0];
+    let prefix = raw_pattern[..wildcard_index].to_string();
+    let suffix = raw_pattern[(wildcard_index + 1)..].to_string();
+
+    Ok(AliasFromPattern {
+        raw: raw_pattern.to_string(),
+        prefix,
+        suffix,
+    })
+}
+
+fn parse_template(
+    rule_index: usize,
+    raw_template: &str,
+) -> Result<AliasTemplate, AliasRuleValidationError> {
+    let mut parts = Vec::new();
+    let mut cursor = 0;
+
+    while cursor < raw_template.len() {
+        let open_offset = raw_template[cursor..].find('{');
+
+        match open_offset {
+            Some(offset) => {
+                let open = cursor + offset;
+                if open > cursor {
+                    parts.push(AliasTemplatePart::Literal(raw_template[cursor..open].to_string()));
+                }
+
+                let token_start = open + 1;
+                let close_offset = raw_template[token_start..].find('}');
+
+                let close = match close_offset {
+                    Some(offset) => token_start + offset,
+                    None => {
+                        return Err(AliasRuleValidationError::to_error(
+                            rule_index,
+                            "to template has an unclosed `{` token".to_string(),
+                        ))
+                    }
+                };
+
+                let token = &raw_template[token_start..close];
+                match token {
+                    "" => parts.push(AliasTemplatePart::Capture),
+                    "snakecase" => parts.push(AliasTemplatePart::SnakecaseCapture),
+                    _ => {
+                        return Err(AliasRuleValidationError::to_error(
+                            rule_index,
+                            format!("unsupported to template token `{{{token}}}`"),
+                        ))
+                    }
+                }
+
+                cursor = close + 1;
+            }
+            None => {
+                parts.push(AliasTemplatePart::Literal(raw_template[cursor..].to_string()));
+                cursor = raw_template.len();
+            }
+        }
+    }
+
+    Ok(AliasTemplate {
+        raw: raw_template.to_string(),
+        parts,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn raw_rule(from: &str, to: &str) -> RawAliasRule {
+        RawAliasRule {
+            from: from.to_string(),
+            to: to.to_string(),
+        }
+    }
+
+    #[test]
+    fn compile_alias_rules_accepts_single_wildcard_and_known_tokens() {
+        let result = compile_alias_rules(&[
+            raw_rule("*?", "be_{}"),
+            raw_rule("has_*?", "have_{}"),
+            raw_rule("*Validator", "{snakecase}"),
+        ]);
+
+        assert_eq!(
+            result,
+            Ok(vec![
+                AliasRule {
+                    from: AliasFromPattern {
+                        raw: "*?".to_string(),
+                        prefix: "".to_string(),
+                        suffix: "?".to_string(),
+                    },
+                    to: AliasTemplate {
+                        raw: "be_{}".to_string(),
+                        parts: vec![
+                            AliasTemplatePart::Literal("be_".to_string()),
+                            AliasTemplatePart::Capture,
+                        ],
+                    },
+                },
+                AliasRule {
+                    from: AliasFromPattern {
+                        raw: "has_*?".to_string(),
+                        prefix: "has_".to_string(),
+                        suffix: "?".to_string(),
+                    },
+                    to: AliasTemplate {
+                        raw: "have_{}".to_string(),
+                        parts: vec![
+                            AliasTemplatePart::Literal("have_".to_string()),
+                            AliasTemplatePart::Capture,
+                        ],
+                    },
+                },
+                AliasRule {
+                    from: AliasFromPattern {
+                        raw: "*Validator".to_string(),
+                        prefix: "".to_string(),
+                        suffix: "Validator".to_string(),
+                    },
+                    to: AliasTemplate {
+                        raw: "{snakecase}".to_string(),
+                        parts: vec![AliasTemplatePart::SnakecaseCapture],
+                    },
+                },
+            ])
+        );
+    }
+
+    #[test]
+    fn compile_alias_rules_rejects_from_without_wildcard() {
+        let result = compile_alias_rules(&[raw_rule("admin?", "be_{}")]).unwrap_err();
+
+        assert_eq!(
+            result,
+            vec![AliasRuleValidationError {
+                rule_index: 0,
+                field: AliasRuleField::From,
+                message: "from pattern must contain exactly one `*` wildcard".to_string(),
+            }]
+        );
+    }
+
+    #[test]
+    fn compile_alias_rules_rejects_from_with_multiple_wildcards() {
+        let result = compile_alias_rules(&[raw_rule("*foo*", "be_{}")]).unwrap_err();
+
+        assert_eq!(
+            result,
+            vec![AliasRuleValidationError {
+                rule_index: 0,
+                field: AliasRuleField::From,
+                message: "from pattern must contain exactly one `*` wildcard".to_string(),
+            }]
+        );
+    }
+
+    #[test]
+    fn compile_alias_rules_rejects_unknown_to_token() {
+        let result = compile_alias_rules(&[raw_rule("*?", "be_{camelcase}")]).unwrap_err();
+
+        assert_eq!(
+            result,
+            vec![AliasRuleValidationError {
+                rule_index: 0,
+                field: AliasRuleField::To,
+                message: "unsupported to template token `{camelcase}`".to_string(),
+            }]
+        );
+    }
+
+    #[test]
+    fn compile_alias_rules_rejects_unclosed_to_token() {
+        let result = compile_alias_rules(&[raw_rule("*?", "be_{")]).unwrap_err();
+
+        assert_eq!(
+            result,
+            vec![AliasRuleValidationError {
+                rule_index: 0,
+                field: AliasRuleField::To,
+                message: "to template has an unclosed `{` token".to_string(),
+            }]
+        );
+    }
+}

--- a/crates/project_configuration/src/default_config.yml
+++ b/crates/project_configuration/src/default_config.yml
@@ -13,6 +13,13 @@
   config_files:
     - db/
     - config/
+  method_aliases:
+    - from: "*?"
+      to: "be_{}"
+    - from: "has_*?"
+      to: "have_{}"
+    - from: "*Validator"
+      to: "{snakecase}"
   auto_low_likelihood:
     - name: Test
       token_ends_with: Test

--- a/crates/project_configuration/src/lib.rs
+++ b/crates/project_configuration/src/lib.rs
@@ -8,7 +8,8 @@ mod value_assertion;
 pub use crate::project_configuration::{PathPrefix, ProjectConfiguration};
 pub use alias_rules::{
     AliasFromPattern, AliasRule, AliasRuleField, AliasRuleValidationError, AliasTemplate,
-    AliasTemplatePart, RawAliasRule, compile_alias_rules,
+    AliasTemplatePart, AliasTransform, RawAliasRule, apply_alias_transforms, compile_alias_rules,
+    expand_alias_candidates, render_alias_template,
 };
 pub use loader::ProjectConfigurations;
 pub use value_assertion::{Assertion, AssertionConflict, ValueMatcher};

--- a/crates/project_configuration/src/lib.rs
+++ b/crates/project_configuration/src/lib.rs
@@ -6,10 +6,6 @@ mod project_configuration;
 mod value_assertion;
 
 pub use crate::project_configuration::{PathPrefix, ProjectConfiguration};
-pub use alias_rules::{
-    AliasFromPattern, AliasRule, AliasRuleField, AliasRuleValidationError, AliasTemplate,
-    AliasTemplatePart, AliasTransform, RawAliasRule, apply_alias_transforms, compile_alias_rules,
-    expand_alias_candidates, render_alias_template,
-};
+pub use alias_rules::expand_alias_candidates;
 pub use loader::ProjectConfigurations;
 pub use value_assertion::{Assertion, AssertionConflict, ValueMatcher};

--- a/crates/project_configuration/src/lib.rs
+++ b/crates/project_configuration/src/lib.rs
@@ -1,5 +1,6 @@
 #![warn(clippy::pedantic)]
 
+mod alias_rules;
 mod loader;
 mod project_configuration;
 mod value_assertion;

--- a/crates/project_configuration/src/lib.rs
+++ b/crates/project_configuration/src/lib.rs
@@ -6,5 +6,9 @@ mod project_configuration;
 mod value_assertion;
 
 pub use crate::project_configuration::{PathPrefix, ProjectConfiguration};
+pub use alias_rules::{
+    AliasFromPattern, AliasRule, AliasRuleField, AliasRuleValidationError, AliasTemplate,
+    AliasTemplatePart, RawAliasRule, compile_alias_rules,
+};
 pub use loader::ProjectConfigurations;
 pub use value_assertion::{Assertion, AssertionConflict, ValueMatcher};

--- a/crates/project_configuration/src/loader.rs
+++ b/crates/project_configuration/src/loader.rs
@@ -1,8 +1,10 @@
+use super::alias_rules::{AliasRule, AliasRuleField, RawAliasRule, compile_alias_rules};
 use super::project_configuration::{LowLikelihoodConfig, PathPrefix, ProjectConfiguration};
 use super::value_assertion::{Assertion, ValueMatcher};
 use serde::Deserialize;
 use serde_yaml::Value;
 use std::collections::{HashMap, HashSet};
+use std::fmt;
 use std::include_str;
 use token_search::TokenSearchResults;
 
@@ -40,6 +42,8 @@ struct RawProjectConfiguration {
     auto_low_likelihood: Vec<RawLowLikelihoodConfig>,
     #[serde(default)]
     matches_if: Vec<HashMap<String, Value>>,
+    #[serde(default)]
+    method_aliases: Vec<RawAliasRule>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -51,6 +55,47 @@ struct RawLowLikelihoodConfig {
 
 pub struct ProjectConfigurations {
     configs: HashMap<String, ProjectConfiguration>,
+}
+
+#[derive(Debug, Eq, PartialEq)]
+pub enum ConfigLoadError {
+    Yaml(String),
+    AliasValidation(Vec<AliasValidationIssue>),
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct AliasValidationIssue {
+    pub config_name: String,
+    pub rule_index: usize,
+    pub field: AliasRuleField,
+    pub message: String,
+}
+
+impl fmt::Display for ConfigLoadError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            ConfigLoadError::Yaml(message) => {
+                write!(f, "Failed to parse project configuration YAML: {message}")
+            }
+            ConfigLoadError::AliasValidation(errors) => {
+                writeln!(f, "Invalid method alias configuration:")?;
+                for error in errors {
+                    writeln!(
+                        f,
+                        "- config `{}` method_aliases[{}].{}: {}",
+                        error.config_name,
+                        error.rule_index,
+                        match error.field {
+                            AliasRuleField::From => "from",
+                            AliasRuleField::To => "to",
+                        },
+                        error.message
+                    )?;
+                }
+                Ok(())
+            }
+        }
+    }
 }
 
 impl ProjectConfigurations {
@@ -65,12 +110,18 @@ impl ProjectConfigurations {
     }
 
     #[must_use]
-    pub fn parse(contents: &str) -> Self {
-        let configs = serde_yaml::from_str::<Vec<RawProjectConfiguration>>(contents).map_or_else(
-            |_| HashMap::new(),
-            |results| Self::parse_all_from_yaml(&results),
-        );
-        ProjectConfigurations { configs }
+    pub fn parse(contents: &str) -> Result<Self, ConfigLoadError> {
+        let raw_results = serde_yaml::from_str::<Vec<RawProjectConfiguration>>(contents)
+            .map_err(|error| ConfigLoadError::Yaml(error.to_string()))?;
+        let configs = Self::parse_all_from_yaml(&raw_results)?;
+        Ok(ProjectConfigurations { configs })
+    }
+
+    #[must_use]
+    pub fn parse_lossy(contents: &str) -> Self {
+        Self::parse(contents).unwrap_or_else(|_| Self {
+            configs: HashMap::new(),
+        })
     }
 
     #[must_use]
@@ -110,33 +161,65 @@ impl ProjectConfigurations {
 
     fn parse_all_from_yaml(
         contents: &[RawProjectConfiguration],
-    ) -> HashMap<String, ProjectConfiguration> {
-        contents
-            .iter()
-            .filter_map(|config| {
-                config.name.as_ref().map(|config_name| {
-                    (
-                        config_name.clone(),
-                        Self::parse_from_yaml(config_name, config),
-                    )
-                })
-            })
-            .collect()
+    ) -> Result<HashMap<String, ProjectConfiguration>, ConfigLoadError> {
+        let mut configs = HashMap::new();
+        let mut validation_errors = Vec::new();
+
+        for config in contents {
+            if let Some(config_name) = config.name.as_ref() {
+                match Self::parse_from_yaml(config_name, config) {
+                    Ok(parsed_config) => {
+                        configs.insert(config_name.clone(), parsed_config);
+                    }
+                    Err(mut errors) => validation_errors.append(&mut errors),
+                }
+            }
+        }
+
+        if validation_errors.is_empty() {
+            Ok(configs)
+        } else {
+            Err(ConfigLoadError::AliasValidation(validation_errors))
+        }
     }
 
     fn parse_from_yaml(
         config_name: &str,
         contents: &RawProjectConfiguration,
-    ) -> ProjectConfiguration {
-        ProjectConfiguration {
+    ) -> Result<ProjectConfiguration, Vec<AliasValidationIssue>> {
+        let method_aliases =
+            Self::parse_method_aliases(config_name, contents.method_aliases.as_slice())?;
+
+        Ok(ProjectConfiguration {
             name: String::from(config_name),
             application_file: Self::parse_path_prefixes(&contents.application_files),
             test_file: Self::parse_path_prefixes(&contents.test_files),
             config_file: Self::parse_path_prefixes(&contents.config_files),
             low_likelihood: Self::parse_low_likelihoods(&contents.auto_low_likelihood),
             matches_if: Self::parse_matches_if(&contents.matches_if),
-            method_aliases: vec![],
+            method_aliases,
+        })
+    }
+
+    fn parse_method_aliases(
+        config_name: &str,
+        method_aliases: &[RawAliasRule],
+    ) -> Result<Vec<AliasRule>, Vec<AliasValidationIssue>> {
+        if method_aliases.is_empty() {
+            return Ok(vec![]);
         }
+
+        compile_alias_rules(method_aliases).map_err(|errors| {
+            errors
+                .into_iter()
+                .map(|error| AliasValidationIssue {
+                    config_name: config_name.to_string(),
+                    rule_index: error.rule_index,
+                    field: error.field,
+                    message: error.message,
+                })
+                .collect()
+        })
     }
 
     fn parse_path_prefixes(paths: &[String]) -> Vec<PathPrefix> {
@@ -304,7 +387,7 @@ mod tests {
 
     #[test]
     fn config_loads_from_yaml() {
-        let configs = ProjectConfigurations::parse(&yaml_contents());
+        let configs = ProjectConfigurations::parse(&yaml_contents()).unwrap();
 
         let rails_config = configs.get("Rails").unwrap();
         assert_eq!(
@@ -397,5 +480,42 @@ mod tests {
         assert_eq!(phoenix_config.test_file, vec![PathPrefix::new("test/"),]);
 
         assert_eq!(phoenix_config.config_file, vec![PathPrefix::new("priv/"),]);
+        assert!(phoenix_config.method_aliases.is_empty());
+    }
+
+    #[test]
+    fn config_load_fails_with_alias_validation_errors() {
+        let yaml = "
+- name: Rails
+  method_aliases:
+    - from: admin?
+      to: be_{}
+    - from: has_*?
+      to: have_{camelcase}
+";
+
+        match ProjectConfigurations::parse(yaml) {
+            Ok(_) => panic!("expected alias validation error"),
+            Err(error) => {
+                assert_eq!(
+                    error,
+                    ConfigLoadError::AliasValidation(vec![
+                        AliasValidationIssue {
+                            config_name: "Rails".to_string(),
+                            rule_index: 0,
+                            field: AliasRuleField::From,
+                            message: "from pattern must contain exactly one `*` wildcard"
+                                .to_string(),
+                        },
+                        AliasValidationIssue {
+                            config_name: "Rails".to_string(),
+                            rule_index: 1,
+                            field: AliasRuleField::To,
+                            message: "unsupported to template token `{camelcase}`".to_string(),
+                        },
+                    ])
+                );
+            }
+        }
     }
 }

--- a/crates/project_configuration/src/loader.rs
+++ b/crates/project_configuration/src/loader.rs
@@ -135,6 +135,7 @@ impl ProjectConfigurations {
             config_file: Self::parse_path_prefixes(&contents.config_files),
             low_likelihood: Self::parse_low_likelihoods(&contents.auto_low_likelihood),
             matches_if: Self::parse_matches_if(&contents.matches_if),
+            method_aliases: vec![],
         }
     }
 

--- a/crates/project_configuration/src/loader.rs
+++ b/crates/project_configuration/src/loader.rs
@@ -385,6 +385,24 @@ mod tests {
         .to_string()
     }
 
+    fn assert_alias_issue(
+        errors: &[AliasValidationIssue],
+        config_name: &str,
+        rule_index: usize,
+        field: AliasRuleField,
+        message_fragment: &str,
+    ) {
+        assert!(
+            errors.iter().any(|error| {
+                error.config_name == config_name
+                    && error.rule_index == rule_index
+                    && error.field == field
+                    && error.message.contains(message_fragment)
+            }),
+            "missing alias validation issue for {config_name} rule {rule_index} {field:?} containing `{message_fragment}`; got: {errors:#?}",
+        );
+    }
+
     #[test]
     fn config_loads_from_yaml() {
         let configs = ProjectConfigurations::parse(&yaml_contents()).unwrap();
@@ -488,34 +506,43 @@ mod tests {
         let yaml = "
 - name: Rails
   method_aliases:
-    - from: admin?
+    - from: '*foo*'
       to: be_{}
     - from: has_*?
       to: have_{camelcase}
+- name: Phoenix
+  method_aliases:
+    - from: 'admin?'
+      to: be_{}
 ";
 
         match ProjectConfigurations::parse(yaml) {
             Ok(_) => panic!("expected alias validation error"),
-            Err(error) => {
-                assert_eq!(
-                    error,
-                    ConfigLoadError::AliasValidation(vec![
-                        AliasValidationIssue {
-                            config_name: "Rails".to_string(),
-                            rule_index: 0,
-                            field: AliasRuleField::From,
-                            message: "from pattern must contain exactly one `*` wildcard"
-                                .to_string(),
-                        },
-                        AliasValidationIssue {
-                            config_name: "Rails".to_string(),
-                            rule_index: 1,
-                            field: AliasRuleField::To,
-                            message: "unsupported to template token `{camelcase}`".to_string(),
-                        },
-                    ])
+            Err(ConfigLoadError::AliasValidation(errors)) => {
+                assert_eq!(errors.len(), 3);
+                assert_alias_issue(
+                    &errors,
+                    "Rails",
+                    0,
+                    AliasRuleField::From,
+                    "exactly one `*` wildcard",
+                );
+                assert_alias_issue(
+                    &errors,
+                    "Rails",
+                    1,
+                    AliasRuleField::To,
+                    "unsupported to template token",
+                );
+                assert_alias_issue(
+                    &errors,
+                    "Phoenix",
+                    0,
+                    AliasRuleField::From,
+                    "exactly one `*` wildcard",
                 );
             }
+            Err(error) => panic!("expected alias validation error, got {error:?}"),
         }
     }
 }

--- a/crates/project_configuration/src/loader.rs
+++ b/crates/project_configuration/src/loader.rs
@@ -109,7 +109,11 @@ impl ProjectConfigurations {
         self.configs.get(name)
     }
 
-    #[must_use]
+    /// Parse project configurations from YAML content.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when YAML is invalid or alias rules fail validation.
     pub fn parse(contents: &str) -> Result<Self, ConfigLoadError> {
         let raw_results = serde_yaml::from_str::<Vec<RawProjectConfiguration>>(contents)
             .map_err(|error| ConfigLoadError::Yaml(error.to_string()))?;
@@ -532,7 +536,7 @@ mod tests {
                     "Rails",
                     1,
                     AliasRuleField::To,
-                    "unsupported to template token",
+                    "unsupported to template transform",
                 );
                 assert_alias_issue(
                     &errors,

--- a/crates/project_configuration/src/loader.rs
+++ b/crates/project_configuration/src/loader.rs
@@ -67,7 +67,7 @@ pub enum ConfigLoadError {
 pub struct AliasValidationIssue {
     pub config_name: String,
     pub rule_index: usize,
-    pub field: AliasRuleField,
+    field: AliasRuleField,
     pub message: String,
 }
 
@@ -119,13 +119,6 @@ impl ProjectConfigurations {
             .map_err(|error| ConfigLoadError::Yaml(error.to_string()))?;
         let configs = Self::parse_all_from_yaml(&raw_results)?;
         Ok(ProjectConfigurations { configs })
-    }
-
-    #[must_use]
-    pub fn parse_lossy(contents: &str) -> Self {
-        Self::parse(contents).unwrap_or_else(|_| Self {
-            configs: HashMap::new(),
-        })
     }
 
     #[must_use]

--- a/crates/project_configuration/src/project_configuration.rs
+++ b/crates/project_configuration/src/project_configuration.rs
@@ -145,13 +145,13 @@ impl ProjectConfiguration {
 
 #[cfg(test)]
 mod tests {
-    use crate::alias_rules::{AliasFromPattern, AliasTemplate, AliasTemplatePart};
-    use crate::ProjectConfigurations;
     use super::super::value_assertion::*;
     use super::*;
+    use crate::ProjectConfigurations;
+    use crate::alias_rules::{AliasFromPattern, AliasTemplate, AliasTemplatePart};
     use std::collections::HashMap;
-    use std::fs;
-    use std::path::PathBuf;
+    use std::io::Write;
+    use tempfile::NamedTempFile;
     use token_search::{Token, TokenSearchConfig};
 
     fn alias_rule(
@@ -307,7 +307,7 @@ mod tests {
                 "?",
                 vec![
                     AliasTemplatePart::Literal("be_".to_string()),
-                    AliasTemplatePart::Capture,
+                    AliasTemplatePart::Capture(vec![]),
                 ],
             )],
             ..ProjectConfiguration::default()
@@ -368,11 +368,9 @@ mod tests {
 
     #[test]
     fn codebase_config_match_is_unchanged_without_alias_rules() {
-        let tmp_path = std::env::temp_dir().join(format!(
-            "unused-phase2-no-alias-{}.rb",
-            std::process::id()
-        ));
-        fs::write(&tmp_path, "be_admin\n").expect("failed to write temp file");
+        let mut tmp_file = NamedTempFile::new().expect("failed to create temp file");
+        write!(tmp_file, "be_admin\n").expect("failed to write temp file");
+        let tmp_path = tmp_file.path().to_path_buf();
 
         let config = TokenSearchConfig {
             filter_tokens: |_| true,
@@ -391,8 +389,6 @@ mod tests {
         };
 
         assert!(!project_configuration.codebase_config_match(&results));
-
-        let _ = fs::remove_file(PathBuf::from(&tmp_path));
     }
 
     #[test]
@@ -404,13 +400,9 @@ mod tests {
         ];
 
         for (source_token, expected_match) in cases {
-            let tmp_path = std::env::temp_dir().join(format!(
-                "unused-phase3-alias-enabled-{}-{}-{}.rb",
-                std::process::id(),
-                source_token,
-                expected_match
-            ));
-            fs::write(&tmp_path, format!("{source_token}\n")).expect("failed to write temp file");
+            let mut tmp_file = NamedTempFile::new().expect("failed to create temp file");
+            write!(tmp_file, "{source_token}\n").expect("failed to write temp file");
+            let tmp_path = tmp_file.path().to_path_buf();
 
             let config = TokenSearchConfig {
                 filter_tokens: |_| true,
@@ -440,8 +432,6 @@ mod tests {
                 project_configuration.codebase_config_match(&results),
                 "expected `{source_token}` to satisfy `{expected_match}` via aliases",
             );
-
-            let _ = fs::remove_file(PathBuf::from(&tmp_path));
         }
     }
 }

--- a/crates/project_configuration/src/project_configuration.rs
+++ b/crates/project_configuration/src/project_configuration.rs
@@ -145,8 +145,38 @@ impl ProjectConfiguration {
 
 #[cfg(test)]
 mod tests {
+    use crate::alias_rules::{AliasFromPattern, AliasTemplate, AliasTemplatePart};
     use super::super::value_assertion::*;
     use super::*;
+    use std::collections::HashMap;
+    use std::fs;
+    use std::path::PathBuf;
+    use token_search::{Token, TokenSearchConfig};
+
+    fn alias_rule(
+        from_prefix: &str,
+        from_suffix: &str,
+        parts: Vec<AliasTemplatePart>,
+    ) -> AliasRule {
+        AliasRule {
+            from: AliasFromPattern {
+                raw: format!("{from_prefix}*{from_suffix}"),
+                prefix: from_prefix.to_string(),
+                suffix: from_suffix.to_string(),
+            },
+            to: AliasTemplate {
+                raw: "test".to_string(),
+                parts,
+            },
+        }
+    }
+
+    fn token_search_result(token_value: &str) -> TokenSearchResult {
+        TokenSearchResult {
+            token: Token::new(token_value.to_string(), Default::default()),
+            occurrences: HashMap::new(),
+        }
+    }
 
     #[test]
     fn low_likelihood_highlights_logical_issues_with_assertions() {
@@ -224,5 +254,89 @@ mod tests {
         };
 
         assert_eq!(no_conflict.conflicts(), vec![]);
+    }
+
+    #[test]
+    fn low_likelihood_match_is_unchanged_without_alias_rules() {
+        let configuration = ProjectConfiguration {
+            low_likelihood: vec![
+                LowLikelihoodConfig {
+                    name: String::from("alias-style"),
+                    matchers: vec![Assertion::TokenAssertion(ValueMatcher::Equals(
+                        "be_admin".to_string(),
+                    ))],
+                },
+                LowLikelihoodConfig {
+                    name: String::from("direct"),
+                    matchers: vec![Assertion::TokenAssertion(ValueMatcher::Equals(
+                        "admin?".to_string(),
+                    ))],
+                },
+            ],
+            ..ProjectConfiguration::default()
+        };
+
+        let result = token_search_result("admin?");
+        let matched = configuration
+            .low_likelihood_match(&result)
+            .expect("expected direct matcher to match");
+
+        assert_eq!(matched.name, "direct");
+    }
+
+    #[test]
+    fn low_likelihood_match_can_diverge_when_alias_rules_exist() {
+        let configuration = ProjectConfiguration {
+            low_likelihood: vec![LowLikelihoodConfig {
+                name: String::from("alias-style"),
+                matchers: vec![Assertion::TokenAssertion(ValueMatcher::Equals(
+                    "be_admin".to_string(),
+                ))],
+            }],
+            method_aliases: vec![alias_rule(
+                "",
+                "?",
+                vec![
+                    AliasTemplatePart::Literal("be_".to_string()),
+                    AliasTemplatePart::Capture,
+                ],
+            )],
+            ..ProjectConfiguration::default()
+        };
+
+        let result = token_search_result("admin?");
+        let matched = configuration
+            .low_likelihood_match(&result)
+            .expect("expected alias-enabled matcher to match");
+
+        assert_eq!(matched.name, "alias-style");
+    }
+
+    #[test]
+    fn codebase_config_match_is_unchanged_without_alias_rules() {
+        let tmp_path = std::env::temp_dir().join(format!(
+            "unused-phase2-no-alias-{}.rb",
+            std::process::id()
+        ));
+        fs::write(&tmp_path, "admin?\n").expect("failed to write temp file");
+
+        let config = TokenSearchConfig {
+            tokens: vec![Token::new("admin?".to_string(), Default::default())],
+            files: vec![tmp_path.clone()],
+            display_progress: false,
+            ..TokenSearchConfig::default()
+        };
+        let results = token_search::TokenSearchResults::generate_with_config(&config);
+
+        let project_configuration = ProjectConfiguration {
+            matches_if: vec![Assertion::TokenAssertion(ValueMatcher::Equals(
+                "be_admin".to_string(),
+            ))],
+            ..ProjectConfiguration::default()
+        };
+
+        assert!(!project_configuration.codebase_config_match(&results));
+
+        let _ = fs::remove_file(PathBuf::from(&tmp_path));
     }
 }

--- a/crates/project_configuration/src/project_configuration.rs
+++ b/crates/project_configuration/src/project_configuration.rs
@@ -38,7 +38,17 @@ pub struct LowLikelihoodConfig {
 
 impl LowLikelihoodConfig {
     pub fn matches(&self, token_search_result: &TokenSearchResult) -> bool {
-        self.matchers.iter().all(|a| a.matches(token_search_result))
+        self.matches_with_aliases(token_search_result, &[])
+    }
+
+    pub fn matches_with_aliases(
+        &self,
+        token_search_result: &TokenSearchResult,
+        alias_rules: &[AliasRule],
+    ) -> bool {
+        self.matchers
+            .iter()
+            .all(|a| a.matches_with_aliases(token_search_result, alias_rules))
     }
 
     pub fn conflicts(&self) -> Vec<AssertionConflict> {
@@ -119,7 +129,7 @@ impl ProjectConfiguration {
     ) -> Option<&LowLikelihoodConfig> {
         self.low_likelihood
             .iter()
-            .find(|ll| ll.matches(token_search_result))
+            .find(|ll| ll.matches_with_aliases(token_search_result, &self.method_aliases))
     }
 
     #[must_use]
@@ -128,7 +138,7 @@ impl ProjectConfiguration {
             results
                 .value()
                 .iter()
-                .any(|result| assertion.matches(result))
+                .any(|result| assertion.matches_with_aliases(result, &self.method_aliases))
         })
     }
 }

--- a/crates/project_configuration/src/project_configuration.rs
+++ b/crates/project_configuration/src/project_configuration.rs
@@ -146,6 +146,7 @@ impl ProjectConfiguration {
 #[cfg(test)]
 mod tests {
     use crate::alias_rules::{AliasFromPattern, AliasTemplate, AliasTemplatePart};
+    use crate::ProjectConfigurations;
     use super::super::value_assertion::*;
     use super::*;
     use std::collections::HashMap;
@@ -176,6 +177,14 @@ mod tests {
             token: Token::new(token_value.to_string(), Default::default()),
             occurrences: HashMap::new(),
         }
+    }
+
+    fn rails_configuration_from_yaml(yaml: &str) -> ProjectConfiguration {
+        ProjectConfigurations::parse(yaml)
+            .expect("expected valid project configuration yaml")
+            .get("Rails")
+            .cloned()
+            .expect("expected Rails configuration")
     }
 
     #[test]
@@ -313,15 +322,61 @@ mod tests {
     }
 
     #[test]
+    fn low_likelihood_match_supports_canonical_alias_equivalence_from_yaml() {
+        let configuration = rails_configuration_from_yaml(
+            "
+- name: Rails
+  method_aliases:
+    - from: '*?'
+      to: be_{}
+    - from: 'has_*?'
+      to: have_{}
+    - from: '*Validator'
+      to: '{snakecase}'
+  auto_low_likelihood:
+    - name: be-style
+      token_equals: be_admin
+    - name: have-style
+      token_equals: have_results
+    - name: snakecase-style
+      token_equals: http
+",
+        );
+
+        assert_eq!(
+            configuration
+                .low_likelihood_match(&token_search_result("admin?"))
+                .expect("expected be-style alias match")
+                .name,
+            "be-style"
+        );
+        assert_eq!(
+            configuration
+                .low_likelihood_match(&token_search_result("has_results?"))
+                .expect("expected have-style alias match")
+                .name,
+            "have-style"
+        );
+        assert_eq!(
+            configuration
+                .low_likelihood_match(&token_search_result("HTTPValidator"))
+                .expect("expected snakecase-style alias match")
+                .name,
+            "snakecase-style"
+        );
+    }
+
+    #[test]
     fn codebase_config_match_is_unchanged_without_alias_rules() {
         let tmp_path = std::env::temp_dir().join(format!(
             "unused-phase2-no-alias-{}.rb",
             std::process::id()
         ));
-        fs::write(&tmp_path, "admin?\n").expect("failed to write temp file");
+        fs::write(&tmp_path, "be_admin\n").expect("failed to write temp file");
 
         let config = TokenSearchConfig {
-            tokens: vec![Token::new("admin?".to_string(), Default::default())],
+            filter_tokens: |_| true,
+            tokens: vec![Token::new("be_admin".to_string(), Default::default())],
             files: vec![tmp_path.clone()],
             display_progress: false,
             ..TokenSearchConfig::default()
@@ -330,7 +385,7 @@ mod tests {
 
         let project_configuration = ProjectConfiguration {
             matches_if: vec![Assertion::TokenAssertion(ValueMatcher::Equals(
-                "be_admin".to_string(),
+                "admin?".to_string(),
             ))],
             ..ProjectConfiguration::default()
         };
@@ -338,5 +393,55 @@ mod tests {
         assert!(!project_configuration.codebase_config_match(&results));
 
         let _ = fs::remove_file(PathBuf::from(&tmp_path));
+    }
+
+    #[test]
+    fn codebase_config_match_supports_canonical_alias_equivalence_from_yaml() {
+        let cases = [
+            ("be_admin", "admin?"),
+            ("have_results", "has_results?"),
+            ("HTTPValidator", "http"),
+        ];
+
+        for (source_token, expected_match) in cases {
+            let tmp_path = std::env::temp_dir().join(format!(
+                "unused-phase3-alias-enabled-{}-{}-{}.rb",
+                std::process::id(),
+                source_token,
+                expected_match
+            ));
+            fs::write(&tmp_path, format!("{source_token}\n")).expect("failed to write temp file");
+
+            let config = TokenSearchConfig {
+                filter_tokens: |_| true,
+                tokens: vec![Token::new(source_token.to_string(), Default::default())],
+                files: vec![tmp_path.clone()],
+                display_progress: false,
+                ..TokenSearchConfig::default()
+            };
+            let results = token_search::TokenSearchResults::generate_with_config(&config);
+
+            let project_configuration = rails_configuration_from_yaml(&format!(
+                "
+- name: Rails
+  method_aliases:
+    - from: '*?'
+      to: be_{{}}
+    - from: 'has_*?'
+      to: have_{{}}
+    - from: '*Validator'
+      to: '{{snakecase}}'
+  matches_if:
+    - token_equals: '{expected_match}'
+",
+            ));
+
+            assert!(
+                project_configuration.codebase_config_match(&results),
+                "expected `{source_token}` to satisfy `{expected_match}` via aliases",
+            );
+
+            let _ = fs::remove_file(PathBuf::from(&tmp_path));
+        }
     }
 }

--- a/crates/project_configuration/src/project_configuration.rs
+++ b/crates/project_configuration/src/project_configuration.rs
@@ -1,3 +1,4 @@
+use super::alias_rules::AliasRule;
 use super::value_assertion::{Assertion, AssertionConflict};
 use std::default::Default;
 use std::path::Path;
@@ -11,6 +12,7 @@ pub struct ProjectConfiguration {
     pub config_file: Vec<PathPrefix>,
     pub low_likelihood: Vec<LowLikelihoodConfig>,
     pub matches_if: Vec<Assertion>,
+    pub method_aliases: Vec<AliasRule>,
 }
 
 #[derive(Clone, Debug, PartialEq)]
@@ -104,6 +106,7 @@ impl Default for ProjectConfiguration {
             config_file: vec![],
             low_likelihood: vec![],
             matches_if: vec![],
+            method_aliases: vec![],
         }
     }
 }

--- a/crates/project_configuration/src/project_configuration.rs
+++ b/crates/project_configuration/src/project_configuration.rs
@@ -150,26 +150,24 @@ mod tests {
     use crate::ProjectConfigurations;
     use crate::alias_rules::{AliasFromPattern, AliasTemplate, AliasTemplatePart};
     use std::collections::HashMap;
-    use std::io::Write;
-    use tempfile::NamedTempFile;
-    use token_search::{Token, TokenSearchConfig};
+    use token_search::Token;
 
     fn alias_rule(
         from_prefix: &str,
         from_suffix: &str,
         parts: Vec<AliasTemplatePart>,
     ) -> AliasRule {
-        AliasRule {
-            from: AliasFromPattern {
+        AliasRule::new(
+            AliasFromPattern {
                 raw: format!("{from_prefix}*{from_suffix}"),
                 prefix: from_prefix.to_string(),
                 suffix: from_suffix.to_string(),
             },
-            to: AliasTemplate {
+            AliasTemplate {
                 raw: "test".to_string(),
                 parts,
             },
-        }
+        )
     }
 
     fn token_search_result(token_value: &str) -> TokenSearchResult {
@@ -364,74 +362,5 @@ mod tests {
                 .name,
             "snakecase-style"
         );
-    }
-
-    #[test]
-    fn codebase_config_match_is_unchanged_without_alias_rules() {
-        let mut tmp_file = NamedTempFile::new().expect("failed to create temp file");
-        write!(tmp_file, "be_admin\n").expect("failed to write temp file");
-        let tmp_path = tmp_file.path().to_path_buf();
-
-        let config = TokenSearchConfig {
-            filter_tokens: |_| true,
-            tokens: vec![Token::new("be_admin".to_string(), Default::default())],
-            files: vec![tmp_path.clone()],
-            display_progress: false,
-            ..TokenSearchConfig::default()
-        };
-        let results = token_search::TokenSearchResults::generate_with_config(&config);
-
-        let project_configuration = ProjectConfiguration {
-            matches_if: vec![Assertion::TokenAssertion(ValueMatcher::Equals(
-                "admin?".to_string(),
-            ))],
-            ..ProjectConfiguration::default()
-        };
-
-        assert!(!project_configuration.codebase_config_match(&results));
-    }
-
-    #[test]
-    fn codebase_config_match_supports_canonical_alias_equivalence_from_yaml() {
-        let cases = [
-            ("be_admin", "admin?"),
-            ("have_results", "has_results?"),
-            ("HTTPValidator", "http"),
-        ];
-
-        for (source_token, expected_match) in cases {
-            let mut tmp_file = NamedTempFile::new().expect("failed to create temp file");
-            write!(tmp_file, "{source_token}\n").expect("failed to write temp file");
-            let tmp_path = tmp_file.path().to_path_buf();
-
-            let config = TokenSearchConfig {
-                filter_tokens: |_| true,
-                tokens: vec![Token::new(source_token.to_string(), Default::default())],
-                files: vec![tmp_path.clone()],
-                display_progress: false,
-                ..TokenSearchConfig::default()
-            };
-            let results = token_search::TokenSearchResults::generate_with_config(&config);
-
-            let project_configuration = rails_configuration_from_yaml(&format!(
-                "
-- name: Rails
-  method_aliases:
-    - from: '*?'
-      to: be_{{}}
-    - from: 'has_*?'
-      to: have_{{}}
-    - from: '*Validator'
-      to: '{{snakecase}}'
-  matches_if:
-    - token_equals: '{expected_match}'
-",
-            ));
-
-            assert!(
-                project_configuration.codebase_config_match(&results),
-                "expected `{source_token}` to satisfy `{expected_match}` via aliases",
-            );
-        }
     }
 }

--- a/crates/project_configuration/src/value_assertion.rs
+++ b/crates/project_configuration/src/value_assertion.rs
@@ -1,4 +1,4 @@
-use super::alias_rules::{AliasRule, AliasTemplatePart};
+use super::alias_rules::{AliasRule, expand_alias_candidates};
 use std::collections::HashSet;
 use token_search::TokenSearchResult;
 
@@ -117,61 +117,12 @@ fn candidate_sets_overlap(first: &HashSet<String>, second: &HashSet<String>) -> 
     first.iter().any(|candidate| second.contains(candidate))
 }
 
-fn expand_alias_candidates(input: &str, alias_rules: &[AliasRule]) -> HashSet<String> {
-    let mut candidates = HashSet::from([input.to_string()]);
-
-    for alias_rule in alias_rules {
-        let Some(capture) = input
-            .strip_prefix(&alias_rule.from.prefix)
-            .and_then(|rest| rest.strip_suffix(&alias_rule.from.suffix))
-        else {
-            continue;
-        };
-
-        let generated = render_alias_template(capture, &alias_rule.to.parts);
-        if generated != input {
-            candidates.insert(generated);
-        }
-    }
-
-    candidates
-}
-
-fn render_alias_template(capture: &str, parts: &[AliasTemplatePart]) -> String {
-    parts
-        .iter()
-        .map(|part| match part {
-            AliasTemplatePart::Literal(value) => value.to_string(),
-            AliasTemplatePart::Capture => capture.to_string(),
-            AliasTemplatePart::SnakecaseCapture => snakecase(capture),
-        })
-        .collect::<Vec<_>>()
-        .join("")
-}
-
-fn snakecase(value: &str) -> String {
-    let mut out = String::new();
-    let chars: Vec<char> = value.chars().collect();
-
-    for (i, ch) in chars.iter().enumerate() {
-        if i > 0 && ch.is_uppercase() {
-            let prev = chars[i - 1];
-            let next_is_lowercase = chars.get(i + 1).is_some_and(|next| next.is_lowercase());
-            if prev.is_lowercase() || (prev.is_uppercase() && next_is_lowercase) {
-                out.push('_');
-            }
-        }
-
-        out.extend(ch.to_lowercase());
-    }
-
-    out
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::alias_rules::{AliasFromPattern, AliasTemplate};
+    use crate::alias_rules::{
+        AliasFromPattern, AliasTemplate, AliasTemplatePart, AliasTransform, render_alias_template,
+    };
 
     fn foo() -> String {
         String::from("foo")
@@ -255,7 +206,7 @@ mod tests {
                     "?",
                     vec![
                         AliasTemplatePart::Literal("be_".to_string()),
-                        AliasTemplatePart::Capture,
+                        AliasTemplatePart::Capture(vec![]),
                     ],
                 ),
                 alias_rule(
@@ -263,7 +214,7 @@ mod tests {
                     "?",
                     vec![
                         AliasTemplatePart::Literal("be_".to_string()),
-                        AliasTemplatePart::Capture,
+                        AliasTemplatePart::Capture(vec![]),
                     ],
                 ),
             ],
@@ -279,13 +230,13 @@ mod tests {
         let candidates = expand_alias_candidates(
             input,
             &[
-                alias_rule("", "?", vec![AliasTemplatePart::Capture]),
+                alias_rule("", "?", vec![AliasTemplatePart::Capture(vec![])]),
                 alias_rule(
                     "",
                     "?",
                     vec![
                         AliasTemplatePart::Literal("be_".to_string()),
-                        AliasTemplatePart::Capture,
+                        AliasTemplatePart::Capture(vec![]),
                     ],
                 ),
                 alias_rule(
@@ -293,7 +244,7 @@ mod tests {
                     "?",
                     vec![
                         AliasTemplatePart::Literal("is_".to_string()),
-                        AliasTemplatePart::Capture,
+                        AliasTemplatePart::Capture(vec![]),
                     ],
                 ),
             ],
@@ -313,7 +264,7 @@ mod tests {
         let input = "admin?";
         let candidates = expand_alias_candidates(
             input,
-            &[alias_rule("", "", vec![AliasTemplatePart::Capture])],
+            &[alias_rule("", "", vec![AliasTemplatePart::Capture(vec![])])],
         );
 
         let expected = HashSet::from([input.to_string()]);
@@ -326,7 +277,7 @@ mod tests {
             "ready!",
             &[
                 AliasTemplatePart::Literal("be_".to_string()),
-                AliasTemplatePart::Capture,
+                AliasTemplatePart::Capture(vec![]),
             ],
         );
 
@@ -335,8 +286,10 @@ mod tests {
 
     #[test]
     fn render_alias_template_supports_snakecase_capture() {
-        let rendered =
-            render_alias_template("HTTPValidator", &[AliasTemplatePart::SnakecaseCapture]);
+        let rendered = render_alias_template(
+            "HTTPValidator",
+            &[AliasTemplatePart::Capture(vec![AliasTransform::Snakecase])],
+        );
 
         assert_eq!(rendered, "http_validator");
     }
@@ -349,7 +302,7 @@ mod tests {
             "?",
             vec![
                 AliasTemplatePart::Literal("be_".to_string()),
-                AliasTemplatePart::Capture,
+                AliasTemplatePart::Capture(vec![]),
             ],
         )];
 
@@ -365,7 +318,7 @@ mod tests {
             "?",
             vec![
                 AliasTemplatePart::Literal("be_".to_string()),
-                AliasTemplatePart::Capture,
+                AliasTemplatePart::Capture(vec![]),
             ],
         )];
 
@@ -380,7 +333,7 @@ mod tests {
             "?",
             vec![
                 AliasTemplatePart::Literal("have_".to_string()),
-                AliasTemplatePart::Capture,
+                AliasTemplatePart::Capture(vec![]),
             ],
         )];
 
@@ -394,7 +347,7 @@ mod tests {
         let aliases = vec![alias_rule(
             "",
             "Validator",
-            vec![AliasTemplatePart::SnakecaseCapture],
+            vec![AliasTemplatePart::Capture(vec![AliasTransform::Snakecase])],
         )];
 
         assert!(!matcher.check("EmailValidator"));
@@ -412,7 +365,7 @@ mod tests {
                     "?",
                     vec![
                         AliasTemplatePart::Literal("be_".to_string()),
-                        AliasTemplatePart::Capture,
+                        AliasTemplatePart::Capture(vec![]),
                     ],
                 ),
                 alias_rule(
@@ -420,7 +373,7 @@ mod tests {
                     "",
                     vec![
                         AliasTemplatePart::Literal("assert_".to_string()),
-                        AliasTemplatePart::Capture,
+                        AliasTemplatePart::Capture(vec![]),
                     ],
                 ),
             ],
@@ -439,7 +392,7 @@ mod tests {
             "?",
             vec![
                 AliasTemplatePart::Literal("be_".to_string()),
-                AliasTemplatePart::Capture,
+                AliasTemplatePart::Capture(vec![]),
             ],
         )];
 
@@ -459,7 +412,7 @@ mod tests {
             "?",
             vec![
                 AliasTemplatePart::Literal("be_".to_string()),
-                AliasTemplatePart::Capture,
+                AliasTemplatePart::Capture(vec![]),
             ],
         )];
 
@@ -475,7 +428,7 @@ mod tests {
             "?",
             vec![
                 AliasTemplatePart::Literal("be_".to_string()),
-                AliasTemplatePart::Capture,
+                AliasTemplatePart::Capture(vec![]),
             ],
         )];
 

--- a/crates/project_configuration/src/value_assertion.rs
+++ b/crates/project_configuration/src/value_assertion.rs
@@ -358,6 +358,80 @@ mod tests {
     }
 
     #[test]
+    fn check_with_aliases_matches_wildcard_question_equivalence() {
+        let matcher = ValueMatcher::Equals("be_admin".to_string());
+        let aliases = vec![alias_rule(
+            "",
+            "?",
+            vec![
+                AliasTemplatePart::Literal("be_".to_string()),
+                AliasTemplatePart::Capture,
+            ],
+        )];
+
+        assert!(matcher.check_with_aliases("admin?", &aliases));
+    }
+
+    #[test]
+    fn check_with_aliases_matches_has_prefix_equivalence() {
+        let matcher = ValueMatcher::Equals("have_feature".to_string());
+        let aliases = vec![alias_rule(
+            "has_",
+            "?",
+            vec![
+                AliasTemplatePart::Literal("have_".to_string()),
+                AliasTemplatePart::Capture,
+            ],
+        )];
+
+        assert!(!matcher.check("has_feature?"));
+        assert!(matcher.check_with_aliases("has_feature?", &aliases));
+    }
+
+    #[test]
+    fn check_with_aliases_matches_snakecase_validator_equivalence() {
+        let matcher = ValueMatcher::Equals("email".to_string());
+        let aliases = vec![alias_rule(
+            "",
+            "Validator",
+            vec![AliasTemplatePart::SnakecaseCapture],
+        )];
+
+        assert!(!matcher.check("EmailValidator"));
+        assert!(matcher.check_with_aliases("EmailValidator", &aliases));
+    }
+
+    #[test]
+    fn expands_alias_candidates_applies_rules_in_one_pass_only() {
+        let input = "admin?";
+        let candidates = expand_alias_candidates(
+            input,
+            &[
+                alias_rule(
+                    "",
+                    "?",
+                    vec![
+                        AliasTemplatePart::Literal("be_".to_string()),
+                        AliasTemplatePart::Capture,
+                    ],
+                ),
+                alias_rule(
+                    "be_",
+                    "",
+                    vec![
+                        AliasTemplatePart::Literal("assert_".to_string()),
+                        AliasTemplatePart::Capture,
+                    ],
+                ),
+            ],
+        );
+
+        let expected = HashSet::from([input.to_string(), "be_admin".to_string()]);
+        assert_eq!(candidates, expected);
+        assert!(!candidates.contains("assert_admin"));
+    }
+
+    #[test]
     fn check_with_aliases_keeps_direct_equals_match_when_aliases_exist() {
         let matcher = ValueMatcher::Equals("be_admin".to_string());
         let aliases = vec![alias_rule(

--- a/crates/project_configuration/src/value_assertion.rs
+++ b/crates/project_configuration/src/value_assertion.rs
@@ -11,6 +11,15 @@ pub enum Assertion {
 impl Assertion {
     #[must_use]
     pub fn matches(&self, token_search_result: &TokenSearchResult) -> bool {
+        self.matches_with_aliases(token_search_result, &[])
+    }
+
+    #[must_use]
+    pub fn matches_with_aliases(
+        &self,
+        token_search_result: &TokenSearchResult,
+        alias_rules: &[AliasRule],
+    ) -> bool {
         match self {
             Assertion::PathAssertion(matcher) => token_search_result
                 .token
@@ -18,7 +27,9 @@ impl Assertion {
                 .iter()
                 .filter_map(|path| path.to_str())
                 .any(|path| matcher.check(path)),
-            Assertion::TokenAssertion(matcher) => matcher.check(&token_search_result.token.token),
+            Assertion::TokenAssertion(matcher) => {
+                matcher.check_with_aliases(&token_search_result.token.token, alias_rules)
+            }
         }
     }
 
@@ -76,6 +87,34 @@ impl ValueMatcher {
             ValueMatcher::Equals(_) | ValueMatcher::ExactMatchOnAnyOf(_)
         )
     }
+
+    #[must_use]
+    pub fn check_with_aliases(&self, haystack: &str, alias_rules: &[AliasRule]) -> bool {
+        if alias_rules.is_empty() {
+            return self.check(haystack);
+        }
+
+        match self {
+            ValueMatcher::Equals(needle) => candidate_sets_overlap(
+                &expand_alias_candidates(haystack, alias_rules),
+                &expand_alias_candidates(needle, alias_rules),
+            ),
+            ValueMatcher::ExactMatchOnAnyOf(values) => {
+                let haystack_candidates = expand_alias_candidates(haystack, alias_rules);
+                values.iter().any(|value| {
+                    candidate_sets_overlap(
+                        &haystack_candidates,
+                        &expand_alias_candidates(value, alias_rules),
+                    )
+                })
+            }
+            _ => self.check(haystack),
+        }
+    }
+}
+
+fn candidate_sets_overlap(first: &HashSet<String>, second: &HashSet<String>) -> bool {
+    first.iter().any(|candidate| second.contains(candidate))
 }
 
 fn expand_alias_candidates(input: &str, alias_rules: &[AliasRule]) -> HashSet<String> {
@@ -287,5 +326,56 @@ mod tests {
             render_alias_template("HTTPValidator", &[AliasTemplatePart::SnakecaseCapture]);
 
         assert_eq!(rendered, "http_validator");
+    }
+
+    #[test]
+    fn check_with_aliases_matches_equals_when_aliases_overlap() {
+        let matcher = ValueMatcher::Equals("be_admin".to_string());
+        let aliases = vec![alias_rule(
+            "",
+            "?",
+            vec![
+                AliasTemplatePart::Literal("be_".to_string()),
+                AliasTemplatePart::Capture,
+            ],
+        )];
+
+        assert!(!matcher.check("admin?"));
+        assert!(matcher.check_with_aliases("admin?", &aliases));
+    }
+
+    #[test]
+    fn check_with_aliases_matches_exact_match_on_any_of_when_aliases_overlap() {
+        let matcher = ValueMatcher::ExactMatchOnAnyOf(
+            ["be_admin".to_string(), "be_staff".to_string()]
+                .into_iter()
+                .collect(),
+        );
+        let aliases = vec![alias_rule(
+            "",
+            "?",
+            vec![
+                AliasTemplatePart::Literal("be_".to_string()),
+                AliasTemplatePart::Capture,
+            ],
+        )];
+
+        assert!(!matcher.check("admin?"));
+        assert!(matcher.check_with_aliases("admin?", &aliases));
+    }
+
+    #[test]
+    fn check_with_aliases_keeps_partial_matchers_unchanged() {
+        let matcher = ValueMatcher::StartsWith("be_".to_string());
+        let aliases = vec![alias_rule(
+            "",
+            "?",
+            vec![
+                AliasTemplatePart::Literal("be_".to_string()),
+                AliasTemplatePart::Capture,
+            ],
+        )];
+
+        assert!(!matcher.check_with_aliases("admin?", &aliases));
     }
 }

--- a/crates/project_configuration/src/value_assertion.rs
+++ b/crates/project_configuration/src/value_assertion.rs
@@ -301,9 +301,22 @@ mod tests {
 
         let expected = HashSet::from([
             input.to_string(),
+            "admin".to_string(),
             "be_admin".to_string(),
             "is_admin".to_string(),
         ]);
+        assert_eq!(candidates, expected);
+    }
+
+    #[test]
+    fn expands_alias_candidates_drops_no_op_generated_values() {
+        let input = "admin?";
+        let candidates = expand_alias_candidates(
+            input,
+            &[alias_rule("", "", vec![AliasTemplatePart::Capture])],
+        );
+
+        let expected = HashSet::from([input.to_string()]);
         assert_eq!(candidates, expected);
     }
 
@@ -342,6 +355,22 @@ mod tests {
 
         assert!(!matcher.check("admin?"));
         assert!(matcher.check_with_aliases("admin?", &aliases));
+    }
+
+    #[test]
+    fn check_with_aliases_keeps_direct_equals_match_when_aliases_exist() {
+        let matcher = ValueMatcher::Equals("be_admin".to_string());
+        let aliases = vec![alias_rule(
+            "",
+            "?",
+            vec![
+                AliasTemplatePart::Literal("be_".to_string()),
+                AliasTemplatePart::Capture,
+            ],
+        )];
+
+        assert!(matcher.check("be_admin"));
+        assert!(matcher.check_with_aliases("be_admin", &aliases));
     }
 
     #[test]

--- a/crates/project_configuration/src/value_assertion.rs
+++ b/crates/project_configuration/src/value_assertion.rs
@@ -1,3 +1,4 @@
+use super::alias_rules::{AliasRule, AliasTemplatePart};
 use std::collections::HashSet;
 use token_search::TokenSearchResult;
 
@@ -77,9 +78,61 @@ impl ValueMatcher {
     }
 }
 
+fn expand_alias_candidates(input: &str, alias_rules: &[AliasRule]) -> HashSet<String> {
+    let mut candidates = HashSet::from([input.to_string()]);
+
+    for alias_rule in alias_rules {
+        let Some(capture) = input
+            .strip_prefix(&alias_rule.from.prefix)
+            .and_then(|rest| rest.strip_suffix(&alias_rule.from.suffix))
+        else {
+            continue;
+        };
+
+        let generated = render_alias_template(capture, &alias_rule.to.parts);
+        if generated != input {
+            candidates.insert(generated);
+        }
+    }
+
+    candidates
+}
+
+fn render_alias_template(capture: &str, parts: &[AliasTemplatePart]) -> String {
+    parts
+        .iter()
+        .map(|part| match part {
+            AliasTemplatePart::Literal(value) => value.to_string(),
+            AliasTemplatePart::Capture => capture.to_string(),
+            AliasTemplatePart::SnakecaseCapture => snakecase(capture),
+        })
+        .collect::<Vec<_>>()
+        .join("")
+}
+
+fn snakecase(value: &str) -> String {
+    let mut out = String::new();
+    let chars: Vec<char> = value.chars().collect();
+
+    for (i, ch) in chars.iter().enumerate() {
+        if i > 0 && ch.is_uppercase() {
+            let prev = chars[i - 1];
+            let next_is_lowercase = chars.get(i + 1).is_some_and(|next| next.is_lowercase());
+            if prev.is_lowercase() || (prev.is_uppercase() && next_is_lowercase) {
+                out.push('_');
+            }
+        }
+
+        out.extend(ch.to_lowercase());
+    }
+
+    out
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::alias_rules::{AliasFromPattern, AliasTemplate};
 
     fn foo() -> String {
         String::from("foo")
@@ -132,5 +185,107 @@ mod tests {
         assert!(!ValueMatcher::Equals(foo()).check("Foo"));
         assert!(!ValueMatcher::Equals(foo()).check(" foo"));
         assert!(!ValueMatcher::Equals(foo()).check("foo "));
+    }
+
+    fn alias_rule(
+        from_prefix: &str,
+        from_suffix: &str,
+        parts: Vec<AliasTemplatePart>,
+    ) -> AliasRule {
+        AliasRule {
+            from: AliasFromPattern {
+                raw: format!("{from_prefix}*{from_suffix}"),
+                prefix: from_prefix.to_string(),
+                suffix: from_suffix.to_string(),
+            },
+            to: AliasTemplate {
+                raw: "test".to_string(),
+                parts,
+            },
+        }
+    }
+
+    #[test]
+    fn expands_alias_candidates_and_dedupes_collisions() {
+        let input = "admin?";
+        let candidates = expand_alias_candidates(
+            input,
+            &[
+                alias_rule(
+                    "",
+                    "?",
+                    vec![
+                        AliasTemplatePart::Literal("be_".to_string()),
+                        AliasTemplatePart::Capture,
+                    ],
+                ),
+                alias_rule(
+                    "",
+                    "?",
+                    vec![
+                        AliasTemplatePart::Literal("be_".to_string()),
+                        AliasTemplatePart::Capture,
+                    ],
+                ),
+            ],
+        );
+
+        let expected = HashSet::from([input.to_string(), "be_admin".to_string()]);
+        assert_eq!(candidates, expected);
+    }
+
+    #[test]
+    fn expands_alias_candidates_with_distinct_outputs_and_drops_self_map() {
+        let input = "admin?";
+        let candidates = expand_alias_candidates(
+            input,
+            &[
+                alias_rule("", "?", vec![AliasTemplatePart::Capture]),
+                alias_rule(
+                    "",
+                    "?",
+                    vec![
+                        AliasTemplatePart::Literal("be_".to_string()),
+                        AliasTemplatePart::Capture,
+                    ],
+                ),
+                alias_rule(
+                    "",
+                    "?",
+                    vec![
+                        AliasTemplatePart::Literal("is_".to_string()),
+                        AliasTemplatePart::Capture,
+                    ],
+                ),
+            ],
+        );
+
+        let expected = HashSet::from([
+            input.to_string(),
+            "be_admin".to_string(),
+            "is_admin".to_string(),
+        ]);
+        assert_eq!(candidates, expected);
+    }
+
+    #[test]
+    fn render_alias_template_preserves_capture_characters() {
+        let rendered = render_alias_template(
+            "ready!",
+            &[
+                AliasTemplatePart::Literal("be_".to_string()),
+                AliasTemplatePart::Capture,
+            ],
+        );
+
+        assert_eq!(rendered, "be_ready!");
+    }
+
+    #[test]
+    fn render_alias_template_supports_snakecase_capture() {
+        let rendered =
+            render_alias_template("HTTPValidator", &[AliasTemplatePart::SnakecaseCapture]);
+
+        assert_eq!(rendered, "http_validator");
     }
 }

--- a/crates/project_configuration/src/value_assertion.rs
+++ b/crates/project_configuration/src/value_assertion.rs
@@ -182,17 +182,17 @@ mod tests {
         from_suffix: &str,
         parts: Vec<AliasTemplatePart>,
     ) -> AliasRule {
-        AliasRule {
-            from: AliasFromPattern {
+        AliasRule::new(
+            AliasFromPattern {
                 raw: format!("{from_prefix}*{from_suffix}"),
                 prefix: from_prefix.to_string(),
                 suffix: from_suffix.to_string(),
             },
-            to: AliasTemplate {
+            AliasTemplate {
                 raw: "test".to_string(),
                 parts,
             },
-        }
+        )
     }
 
     #[test]

--- a/crates/token_search/Cargo.toml
+++ b/crates/token_search/Cargo.toml
@@ -17,3 +17,6 @@ rayon = { workspace = true }
 read_ctags = { path = "../../crates/read_ctags" }
 serde = { workspace = true }
 serde_json = { workspace = true }
+
+[dev-dependencies]
+tempfile = { workspace = true }

--- a/crates/token_search/Cargo.toml
+++ b/crates/token_search/Cargo.toml
@@ -19,4 +19,4 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 
 [dev-dependencies]
-tempfile = { workspace = true }
+tempfile = "3.26"

--- a/crates/token_search/src/token_search.rs
+++ b/crates/token_search/src/token_search.rs
@@ -24,6 +24,11 @@ pub struct TokenSearchConfig {
     pub filter_tokens: fn(&Token) -> bool,
     /// Tokens to be used when searching
     pub tokens: Vec<Token>,
+    /// Additional search terms per token key (for example alias-derived forms).
+    ///
+    /// Keys are canonical token values from `tokens`; values are extra terms that should count as
+    /// occurrences for that canonical token.
+    pub token_aliases: HashMap<String, HashSet<String>>,
     /// Filenames to search against
     pub files: Vec<PathBuf>,
     /// Should a progress bar be displayed?
@@ -79,6 +84,7 @@ impl Default for TokenSearchConfig {
                     && !t.only_ctag(|ct| ct.kind == TokenKind::RSpecDescribe)
             },
             tokens: vec![],
+            token_aliases: HashMap::new(),
             files: CodebaseFiles::all().paths,
             display_progress: true,
             language_restriction: LanguageRestriction::Except(
@@ -160,7 +166,8 @@ impl TokenSearchResults {
             .filter(|t| config.filter_token(t) && config.filter_language(t))
             .collect();
 
-        let tokens: Vec<_> = filtered_results.iter().map(|r| &r.token).collect();
+        let (tokens, pattern_to_token_indices) =
+            build_search_patterns(&filtered_results, &config.token_aliases);
         let Ok(ac) = AhoCorasickBuilder::new()
             .match_kind(MatchKind::LeftmostLongest)
             .build(tokens)
@@ -176,7 +183,9 @@ impl TokenSearchResults {
                 if let Ok(contents) = Self::read_file(f) {
                     let mut counts: HashMap<usize, usize> = HashMap::new();
                     for matched in ac.find_iter(&contents) {
-                        *counts.entry(matched.pattern().as_usize()).or_insert(0) += 1;
+                        for token_idx in &pattern_to_token_indices[matched.pattern().as_usize()] {
+                            *counts.entry(*token_idx).or_insert(0) += 1;
+                        }
                     }
 
                     for (key, res) in counts {
@@ -213,6 +222,42 @@ impl TokenSearchResults {
 
         Ok(contents)
     }
+}
+
+fn build_search_patterns<'a>(
+    filtered_results: &[&'a Token],
+    token_aliases: &HashMap<String, HashSet<String>>,
+) -> (Vec<String>, Vec<Vec<usize>>) {
+    let mut patterns: Vec<String> = Vec::new();
+    let mut pattern_to_token_indices: Vec<Vec<usize>> = Vec::new();
+    let mut pattern_index_by_term: HashMap<String, usize> = HashMap::new();
+
+    for (token_idx, token) in filtered_results.iter().enumerate() {
+        let mut search_terms = HashSet::from([token.token.clone()]);
+        if let Some(alias_terms) = token_aliases.get(&token.token) {
+            search_terms.extend(alias_terms.iter().cloned());
+        }
+
+        let mut ordered_terms = search_terms.into_iter().collect::<Vec<_>>();
+        ordered_terms.sort();
+
+        for search_term in ordered_terms {
+            if search_term.is_empty() {
+                continue;
+            }
+
+            if let Some(existing_pattern_idx) = pattern_index_by_term.get(&search_term) {
+                pattern_to_token_indices[*existing_pattern_idx].push(token_idx);
+            } else {
+                let pattern_idx = patterns.len();
+                pattern_index_by_term.insert(search_term.clone(), pattern_idx);
+                patterns.push(search_term);
+                pattern_to_token_indices.push(vec![token_idx]);
+            }
+        }
+    }
+
+    (patterns, pattern_to_token_indices)
 }
 
 impl Serialize for TokenSearchResults {
@@ -255,5 +300,70 @@ impl TokenSearchResult {
 
     fn all_occurred_paths(&self) -> HashSet<PathBuf> {
         self.occurrences.keys().cloned().collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    fn config_for_file(path: &PathBuf, tokens: Vec<Token>) -> TokenSearchConfig {
+        TokenSearchConfig {
+            filter_tokens: |_| true,
+            tokens,
+            files: vec![path.clone()],
+            display_progress: false,
+            language_restriction: LanguageRestriction::NoRestriction,
+            ..TokenSearchConfig::default()
+        }
+    }
+
+    #[test]
+    fn search_counts_alias_occurrences_against_canonical_token() {
+        let path = std::env::temp_dir().join(format!(
+            "unused-token-search-alias-{}-1.rb",
+            std::process::id()
+        ));
+        fs::write(&path, "expect(span_stub).to have_attribute(\"x\")\n").expect("write");
+
+        let token = Token::new("has_attribute?".to_string(), Default::default());
+        let mut config = config_for_file(&path, vec![token]);
+        config.token_aliases.insert(
+            "has_attribute?".to_string(),
+            HashSet::from([String::from("have_attribute")]),
+        );
+
+        let results = TokenSearchResults::generate_with_config(&config);
+        let has_attribute = results
+            .value()
+            .iter()
+            .find(|result| result.token.token == "has_attribute?")
+            .expect("canonical token result");
+
+        assert_eq!(has_attribute.occurrences.get(&path), Some(&1));
+        let _ = fs::remove_file(&path);
+    }
+
+    #[test]
+    fn search_without_alias_term_does_not_report_alias_only_usage() {
+        let path = std::env::temp_dir().join(format!(
+            "unused-token-search-alias-{}-2.rb",
+            std::process::id()
+        ));
+        fs::write(&path, "expect(span_stub).to have_attribute(\"x\")\n").expect("write");
+
+        let token = Token::new("has_attribute?".to_string(), Default::default());
+        let config = config_for_file(&path, vec![token]);
+        let results = TokenSearchResults::generate_with_config(&config);
+
+        assert!(
+            results
+                .value()
+                .iter()
+                .all(|result| result.token.token != "has_attribute?"),
+            "alias-only usage should not appear without alias search terms"
+        );
+        let _ = fs::remove_file(&path);
     }
 }

--- a/crates/token_search/src/token_search.rs
+++ b/crates/token_search/src/token_search.rs
@@ -224,8 +224,8 @@ impl TokenSearchResults {
     }
 }
 
-fn build_search_patterns<'a>(
-    filtered_results: &[&'a Token],
+fn build_search_patterns(
+    filtered_results: &[&Token],
     token_aliases: &HashMap<String, HashSet<String>>,
 ) -> (Vec<String>, Vec<Vec<usize>>) {
     let mut patterns: Vec<String> = Vec::new();
@@ -306,7 +306,8 @@ impl TokenSearchResult {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::fs;
+    use std::io::Write;
+    use tempfile::NamedTempFile;
 
     fn config_for_file(path: &PathBuf, tokens: Vec<Token>) -> TokenSearchConfig {
         TokenSearchConfig {
@@ -321,11 +322,9 @@ mod tests {
 
     #[test]
     fn search_counts_alias_occurrences_against_canonical_token() {
-        let path = std::env::temp_dir().join(format!(
-            "unused-token-search-alias-{}-1.rb",
-            std::process::id()
-        ));
-        fs::write(&path, "expect(span_stub).to have_attribute(\"x\")\n").expect("write");
+        let mut tmp_file = NamedTempFile::new().expect("create temp file");
+        write!(tmp_file, "expect(span_stub).to have_attribute(\"x\")\n").expect("write");
+        let path = tmp_file.path().to_path_buf();
 
         let token = Token::new("has_attribute?".to_string(), Default::default());
         let mut config = config_for_file(&path, vec![token]);
@@ -342,16 +341,13 @@ mod tests {
             .expect("canonical token result");
 
         assert_eq!(has_attribute.occurrences.get(&path), Some(&1));
-        let _ = fs::remove_file(&path);
     }
 
     #[test]
     fn search_without_alias_term_does_not_report_alias_only_usage() {
-        let path = std::env::temp_dir().join(format!(
-            "unused-token-search-alias-{}-2.rb",
-            std::process::id()
-        ));
-        fs::write(&path, "expect(span_stub).to have_attribute(\"x\")\n").expect("write");
+        let mut tmp_file = NamedTempFile::new().expect("create temp file");
+        write!(tmp_file, "expect(span_stub).to have_attribute(\"x\")\n").expect("write");
+        let path = tmp_file.path().to_path_buf();
 
         let token = Token::new("has_attribute?".to_string(), Default::default());
         let config = config_for_file(&path, vec![token]);
@@ -364,6 +360,5 @@ mod tests {
                 .all(|result| result.token.token != "has_attribute?"),
             "alias-only usage should not appear without alias search terms"
         );
-        let _ = fs::remove_file(&path);
     }
 }

--- a/justfile
+++ b/justfile
@@ -1,5 +1,10 @@
 [group('dev')]
+local-dev: setup-watch
+  CARGO_TEST=1 cargo watch -x "nextest run --workspace"
+
+[group('dev')]
 setup:
+  just setup-watch
   just setup-nextest
   just setup-coverage
   just setup-audit
@@ -8,6 +13,10 @@ setup:
 [group('dev')]
 setup-nextest:
   cargo install cargo-nextest --locked
+
+[group('dev')]
+setup-watch:
+  cargo install cargo-watch --locked
 
 [group('dev')]
 setup-coverage:


### PR DESCRIPTION
- **feat(01-01): add alias rule model and grammar validator**
- **feat(01-01): add alias rules to project configuration model**
- **feat(01-01): export alias rule contracts from crate root**
- **feat(01-02): add alias-aware result-based config parsing**
- **feat(01-02): add default Rails method alias rules**
- **fix(01-02): surface config parse failures in cli and doctor**
- **feat(02-01): implement alias candidate expansion helpers**
- **feat(02-01): apply alias-aware assertion matching**
- **test(02-02): add alias matcher regression coverage**
- **test(02-02): add no-alias project configuration regressions**
- **test(03-02): harden loader alias validation assertions**
- **test(03-01): harden alias rule validation coverage**
- **test(03-01): expand alias matcher equivalence and one-pass coverage**
- **test(03-02): expand project-level alias regression coverage**
- **fix: count alias-derived usages when alias token is absent from tags**
- **chore: adjust style**
